### PR TITLE
New file path for split configuration

### DIFF
--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -9,7 +9,7 @@ module Semaphore
   class CucumberBooster
     def initialize(thread_index)
       @thread_index = thread_index
-      @report_path = ENV["REPORT_PATH"] || "#{ENV["HOME"]}/cucumber_report.json"
+      @cucumber_file_distribution_path = ENV["REPORT_PATH"] || "#{ENV["HOME"]}/cucumber_file_distribution.json"
       @spec_path = ENV["SPEC_PATH"] || "features"
     end
 
@@ -41,21 +41,21 @@ module Semaphore
 
     def select
       with_fallback do
-        feature_report = JSON.parse(File.read(@report_path))
-        thread_count = feature_report.count
-        thread = feature_report[@thread_index]
+        file_distribution = JSON.parse(File.read(@cucumber_file_distribution_path))
+        thread_count = file_distribution.count
+        thread = file_distribution[@thread_index]
 
         all_features = Dir["#{@spec_path}/**/*.feature"].sort
         all_known_features = feature_report.map { |t| t["files"] }.flatten.sort
 
         all_leftover_features = all_features - all_known_features
-        thread_leftover_features = LeftoverFiles::select(all_leftover_features, thread_count, @thread_index)
+        thread_leftover_features = LeftoverFiles.select(all_leftover_features, thread_count, @thread_index)
         thread_features = all_features & thread["files"].sort
         features_to_run = thread_features + thread_leftover_features
 
-        Semaphore::display_files("This thread features:", thread_features)
-        Semaphore::display_title_and_count("All leftover features:", all_leftover_features)
-        Semaphore::display_files("This thread leftover features:", thread_leftover_features)
+        Semaphore.display_files("This thread features:", thread_features)
+        Semaphore.display_title_and_count("All leftover features:", all_leftover_features)
+        Semaphore.display_files("This thread leftover features:", thread_leftover_features)
 
         features_to_run
       end
@@ -73,7 +73,7 @@ module Semaphore
 
       error += %{Exception: #{e.message}}
 
-      Semaphore::log(error)
+      Semaphore.log(error)
 
       raise
     end

--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -9,7 +9,7 @@ module Semaphore
   class CucumberBooster
     def initialize(thread_index)
       @thread_index = thread_index
-      @cucumber_file_distribution_path = ENV["REPORT_PATH"] || "#{ENV["HOME"]}/cucumber_file_distribution.json"
+      @cucumber_file_distribution_path = ENV["CUCUMBER_FILE_DISTRIBUTION_PATH"] || "#{ENV["HOME"]}/cucumber_file_distribution.json"
       @spec_path = ENV["SPEC_PATH"] || "features"
     end
 
@@ -46,7 +46,7 @@ module Semaphore
         thread = file_distribution[@thread_index]
 
         all_features = Dir["#{@spec_path}/**/*.feature"].sort
-        all_known_features = feature_report.map { |t| t["files"] }.flatten.sort
+        all_known_features = file_distribution.map { |t| t["files"] }.flatten.sort
 
         all_leftover_features = all_features - all_known_features
         thread_leftover_features = LeftoverFiles.select(all_leftover_features, thread_count, @thread_index)

--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -9,7 +9,7 @@ module Semaphore
   class CucumberBooster
     def initialize(thread_index)
       @thread_index = thread_index
-      @cucumber_file_distribution_path = ENV["CUCUMBER_FILE_DISTRIBUTION_PATH"] || "#{ENV["HOME"]}/cucumber_file_distribution.json"
+      @cucumber_split_configuration_path = ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] || "#{ENV["HOME"]}/cucumber_split_configuration.json"
       @spec_path = ENV["SPEC_PATH"] || "features"
     end
 
@@ -41,7 +41,7 @@ module Semaphore
 
     def select
       with_fallback do
-        file_distribution = JSON.parse(File.read(@cucumber_file_distribution_path))
+        file_distribution = JSON.parse(File.read(@cucumber_split_configuration_path))
         thread_count = file_distribution.count
         thread = file_distribution[@thread_index]
 

--- a/lib/test_boosters/rspec_booster.rb
+++ b/lib/test_boosters/rspec_booster.rb
@@ -20,7 +20,7 @@ module Semaphore
         specs_to_run = select
 
         if specs_to_run.empty?
-            puts "No spec files in this thread!"
+          puts "No spec files in this thread!"
         else
           exit_code = run_command(specs_to_run.join(" "))
         end
@@ -39,7 +39,7 @@ module Semaphore
       puts "========================= Running Rspec =========================="
       puts
 
-      Semaphore::execute("bundle exec rspec #{options} #{specs}")
+      Semaphore.execute("bundle exec rspec #{options} #{specs}")
     end
 
     def select
@@ -52,13 +52,13 @@ module Semaphore
         all_known_specs = rspec_file_distribution.map { |t| t["files"] }.flatten.sort
 
         all_leftover_specs = all_specs - all_known_specs
-        thread_leftover_specs = LeftoverFiles::select(all_leftover_specs, thread_count, @thread_index)
+        thread_leftover_specs = LeftoverFiles.select(all_leftover_specs, thread_count, @thread_index)
         thread_specs = all_specs & thread["files"].sort
         specs_to_run = thread_specs + thread_leftover_specs
 
-        Semaphore::display_files("This thread specs:", thread_specs)
-        Semaphore::display_title_and_count("All leftover specs:", all_leftover_specs)
-        Semaphore::display_files("This thread leftover specs:", thread_leftover_specs)
+        Semaphore.display_files("This thread specs:", thread_specs)
+        Semaphore.display_title_and_count("All leftover specs:", all_leftover_specs)
+        Semaphore.display_files("This thread leftover specs:", thread_leftover_specs)
 
         specs_to_run
       end
@@ -76,7 +76,7 @@ module Semaphore
       error += %{Exception: #{e.message}\n#{e.backtrace.join("\n")}}
 
       puts error
-      Semaphore::log(error)
+      Semaphore.log(error)
 
       raise
     end

--- a/lib/test_boosters/rspec_booster.rb
+++ b/lib/test_boosters/rspec_booster.rb
@@ -9,7 +9,7 @@ module Semaphore
   class RspecBooster
     def initialize(thread_index)
       @thread_index = thread_index
-      @rspec_file_distribution_path = ENV["RSPEC_FILE_DISTRIBUTION_PATH"] || "#{ENV["HOME"]}/rspec_file_distribution.json"
+      @rspec_split_configuration_path = ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] || "#{ENV["HOME"]}/rspec_split_configuration.json"
       @report_path = ENV["REPORT_PATH"] || "#{ENV["HOME"]}/rspec_report.json"
       @spec_path = ENV["SPEC_PATH"] || "spec"
     end
@@ -44,12 +44,12 @@ module Semaphore
 
     def select
       with_fallback do
-        rspec_file_distribution = JSON.parse(File.read(@rspec_file_distribution_path))
-        thread_count = rspec_file_distribution.count
-        thread = rspec_file_distribution[@thread_index]
+        file_distribution = JSON.parse(File.read(@rspec_split_configuration_path))
+        thread_count = file_distribution.count
+        thread = file_distribution[@thread_index]
 
         all_specs = Dir["#{@spec_path}/**/*_spec.rb"].sort
-        all_known_specs = rspec_file_distribution.map { |t| t["files"] }.flatten.sort
+        all_known_specs = file_distribution.map { |t| t["files"] }.flatten.sort
 
         all_leftover_specs = all_specs - all_known_specs
         thread_leftover_specs = LeftoverFiles.select(all_leftover_specs, thread_count, @thread_index)

--- a/lib/test_boosters/rspec_booster.rb
+++ b/lib/test_boosters/rspec_booster.rb
@@ -9,6 +9,7 @@ module Semaphore
   class RspecBooster
     def initialize(thread_index)
       @thread_index = thread_index
+      @rspec_file_distribution_path = ENV["RSPEC_FILE_DISTRIBUTION_PATH"] || "#{ENV["HOME"]}/rspec_file_distribution.json"
       @report_path = ENV["REPORT_PATH"] || "#{ENV["HOME"]}/rspec_report.json"
       @spec_path = ENV["SPEC_PATH"] || "spec"
     end
@@ -43,12 +44,12 @@ module Semaphore
 
     def select
       with_fallback do
-        rspec_report = JSON.parse(File.read(@report_path))
-        thread_count = rspec_report.count
-        thread = rspec_report[@thread_index]
+        rspec_file_distribution = JSON.parse(File.read(@rspec_file_distribution_path))
+        thread_count = rspec_file_distribution.count
+        thread = rspec_file_distribution[@thread_index]
 
         all_specs = Dir["#{@spec_path}/**/*_spec.rb"].sort
-        all_known_specs = rspec_report.map { |t| t["files"] }.flatten.sort
+        all_known_specs = rspec_file_distribution.map { |t| t["files"] }.flatten.sort
 
         all_leftover_specs = all_specs - all_known_specs
         thread_leftover_specs = LeftoverFiles::select(all_leftover_specs, thread_count, @thread_index)

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/spec/cucumber_boosters_spec.rb
+++ b/spec/cucumber_boosters_spec.rb
@@ -3,47 +3,47 @@ require 'spec_helper'
 CuBooster = Semaphore::CucumberBooster
 
 describe Semaphore::CucumberBooster do
-  context "test select()" do
+  describe "test select()" do
     before(:context) do
-      @report_file = "/tmp/cucumber_report.json"
-      ENV["REPORT_PATH"] = @report_file
+      @test_distribution_file = "/tmp/cucumber_file_distribution.json"
+      ENV["CUCUMBER_FILE_DISTRIBUTION_PATH"] = @test_distribution_file
       ENV["SPEC_PATH"]   = "test_data"
     end
 
     it "2 threads running in thread 1, no scheduled specs, 3 leftover specs" do
       expected = [a, b]
-      write_report_file('[{"files": []}, {"files": []}]')
+      write_test_distribution_file('[{"files": []}, {"files": []}]')
 
       expect(CuBooster.new(0).select).to eq(expected)
     end
 
     it "2 threads running in thread 2, no scheduled specs, 3 leftover specs" do
       expected = [c]
-      write_report_file('[{"files": []}, {"files": []}]')
+      write_test_distribution_file('[{"files": []}, {"files": []}]')
 
       expect(CuBooster.new(1).select).to eq(expected)
     end
 
     it "4 threads running in thread 4, no scheduled specs, 3 leftover specs" do
       expected = []
-      write_report_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
+      write_test_distribution_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
 
       expect(CuBooster.new(3).select).to eq(expected)
     end
 
     it "4 threads, running in thread 1, no scheduled specs, 3 leftover specs" do
-      write_report_file('{"malformed": []}')
+      write_test_distribution_file('{"malformed": []}')
 
       expect{CuBooster.new(0).select}.to raise_error(StandardError)
     end
   end
 
-  context "script invocation" do
+  describe "script invocation" do
     before(:context) do
       @scripts = "exe"
-      @report_file = "/tmp/cucumber_report.json"
-      ENV["REPORT_PATH"] = @report_file
-      write_report_file('[{"files": []}]')
+      @test_distribution_file = "/tmp/cucumber_file_distribution.json"
+      ENV["CUCUMBER_FILE_DISTRIBUTION_PATH"] = @test_distribution_file
+      write_test_distribution_file('[{"files": []}]')
     end
 
     it "checks exit code - test pass" do
@@ -54,8 +54,8 @@ describe Semaphore::CucumberBooster do
     end
   end
 
-  def write_report_file(report)
-    File.write(@report_file, report)
+  def write_test_distribution_file(report)
+    File.write(@test_distribution_file, report)
   end
 
   def a() Setup::Cucumber.a end

--- a/spec/cucumber_boosters_spec.rb
+++ b/spec/cucumber_boosters_spec.rb
@@ -5,34 +5,34 @@ CuBooster = Semaphore::CucumberBooster
 describe Semaphore::CucumberBooster do
   describe "test select()" do
     before(:context) do
-      @test_distribution_file = "/tmp/cucumber_file_distribution.json"
-      ENV["CUCUMBER_FILE_DISTRIBUTION_PATH"] = @test_distribution_file
+      @test_split_configuration = "/tmp/cucumber_split_configuration.json"
+      ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] = @test_split_configuration
       ENV["SPEC_PATH"]   = "test_data"
     end
 
     it "2 threads running in thread 1, no scheduled specs, 3 leftover specs" do
       expected = [a, b]
-      write_test_distribution_file('[{"files": []}, {"files": []}]')
+      write_split_configuration_file('[{"files": []}, {"files": []}]')
 
       expect(CuBooster.new(0).select).to eq(expected)
     end
 
     it "2 threads running in thread 2, no scheduled specs, 3 leftover specs" do
       expected = [c]
-      write_test_distribution_file('[{"files": []}, {"files": []}]')
+      write_split_configuration_file('[{"files": []}, {"files": []}]')
 
       expect(CuBooster.new(1).select).to eq(expected)
     end
 
     it "4 threads running in thread 4, no scheduled specs, 3 leftover specs" do
       expected = []
-      write_test_distribution_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
+      write_split_configuration_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
 
       expect(CuBooster.new(3).select).to eq(expected)
     end
 
     it "4 threads, running in thread 1, no scheduled specs, 3 leftover specs" do
-      write_test_distribution_file('{"malformed": []}')
+      write_split_configuration_file('{"malformed": []}')
 
       expect{CuBooster.new(0).select}.to raise_error(StandardError)
     end
@@ -41,9 +41,9 @@ describe Semaphore::CucumberBooster do
   describe "script invocation" do
     before(:context) do
       @scripts = "exe"
-      @test_distribution_file = "/tmp/cucumber_file_distribution.json"
-      ENV["CUCUMBER_FILE_DISTRIBUTION_PATH"] = @test_distribution_file
-      write_test_distribution_file('[{"files": []}]')
+      @test_split_configuration = "/tmp/cucumber_split_configuration.json"
+      ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] = @test_split_configuration
+      write_split_configuration_file('[{"files": []}]')
     end
 
     it "checks exit code - test pass" do
@@ -54,8 +54,8 @@ describe Semaphore::CucumberBooster do
     end
   end
 
-  def write_test_distribution_file(report)
-    File.write(@test_distribution_file, report)
+  def write_split_configuration_file(report)
+    File.write(@test_split_configuration, report)
   end
 
   def a() Setup::Cucumber.a end

--- a/spec/rspec_booster_spec.rb
+++ b/spec/rspec_booster_spec.rb
@@ -13,34 +13,34 @@ describe Semaphore::RspecBooster do
 
   describe "test select()" do
     before(:context) do
-      @test_distribution_file = "/tmp/rspec_file_distribution.json"
-      ENV["RSPEC_FILE_DISTRIBUTION_PATH"] = @test_distribution_file
+      @test_split_configuration = "/tmp/rspec_split_configuration.json"
+      ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = @test_split_configuration
       ENV["SPEC_PATH"] = Setup.spec_dir()
     end
 
     it "2 threads running in thread 1, no scheduled specs, 3 leftover specs" do
       expected = [a, b]
-      write_test_distribution_file('[{"files": []}, {"files": []}]')
+      write_split_configuration_file('[{"files": []}, {"files": []}]')
 
       expect(Booster.new(0).select).to eq(expected)
     end
 
     it "2 threads running in thread 2, no scheduled specs, 3 leftover specs" do
       expected = [c]
-      write_test_distribution_file('[{"files": []}, {"files": []}]')
+      write_split_configuration_file('[{"files": []}, {"files": []}]')
 
       expect(Booster.new(1).select).to eq(expected)
     end
 
     it "4 threads running in thread 4, no scheduled specs, 3 leftover specs" do
       expected = []
-      write_test_distribution_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
+      write_split_configuration_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
 
       expect(Booster.new(3).select).to eq(expected)
     end
 
     it "4 threads, running in thread 1, no scheduled specs, 3 leftover specs" do
-      write_test_distribution_file('{"malformed": []}')
+      write_split_configuration_file('{"malformed": []}')
 
       expect{Booster.new(0).select}.to raise_error(StandardError)
     end
@@ -57,14 +57,14 @@ describe Semaphore::RspecBooster do
 
   describe "report-file creation" do
     before(:context) do
-      @test_distribution_file = "/tmp/rspec_file_distribution.json"
-      ENV["FILE_DISTRIBUTION_PATH"] = @test_distribution_file
+      @test_split_configuration = "/tmp/rspec_split_configuration.json"
+      ENV["FILE_DISTRIBUTION_PATH"] = @test_split_configuration
     end
 
     it "runs rspec and checks for report file existence" do
       spec_dir = Setup.spec_dir()
 
-      File.delete(@test_distribution_file) if File.exist?(@test_distribution_file)
+      File.delete(@test_split_configuration) if File.exist?(@test_split_configuration)
       expect(Booster.new(0).run_command(spec_dir)).to eq(0)
       expect(File).to exist(@report_file)
     end
@@ -74,13 +74,13 @@ describe Semaphore::RspecBooster do
     before(:context) do
       @scripts = "exe"
 
-      @test_distribution_file = "/tmp/rspec_file_distribution.json"
-      ENV["RSPEC_FILE_DISTRIBUTION_PATH"] = @test_distribution_file
+      @test_split_configuration = "/tmp/rspec_split_configuration.json"
+      ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = @test_split_configuration
 
       @report_file = "/tmp/rspec_report.json"
       ENV["REPORT_PATH"] = @report_file
 
-      write_test_distribution_file('[{"files": []}]')
+      write_split_configuration_file('[{"files": []}]')
     end
 
     it "checks exit code - test fail" do
@@ -105,7 +105,7 @@ describe Semaphore::RspecBooster do
     end
   end
 
-  def write_test_distribution_file(report)
-    File.write(@test_distribution_file, report)
+  def write_split_configuration_file(report)
+    File.write(@test_split_configuration, report)
   end
 end

--- a/spec/rspec_booster_spec.rb
+++ b/spec/rspec_booster_spec.rb
@@ -7,36 +7,40 @@ describe Semaphore::RspecBooster do
     expect(TestBoosters::VERSION).not_to be nil
   end
 
-  context "test select()" do
+  before do
+    @report_file = "#{ENV["HOME"]}/rspec_report.json"
+  end
+
+  describe "test select()" do
     before(:context) do
-      @report_file = "/tmp/rspec_report.json"
-      ENV["REPORT_PATH"] = @report_file
-      ENV["SPEC_PATH"]   = Setup.spec_dir()
+      @test_distribution_file = "/tmp/rspec_file_distribution.json"
+      ENV["RSPEC_FILE_DISTRIBUTION_PATH"] = @test_distribution_file
+      ENV["SPEC_PATH"] = Setup.spec_dir()
     end
 
     it "2 threads running in thread 1, no scheduled specs, 3 leftover specs" do
       expected = [a, b]
-      write_report_file('[{"files": []}, {"files": []}]')
+      write_test_distribution_file('[{"files": []}, {"files": []}]')
 
       expect(Booster.new(0).select).to eq(expected)
     end
 
     it "2 threads running in thread 2, no scheduled specs, 3 leftover specs" do
       expected = [c]
-      write_report_file('[{"files": []}, {"files": []}]')
+      write_test_distribution_file('[{"files": []}, {"files": []}]')
 
       expect(Booster.new(1).select).to eq(expected)
     end
 
     it "4 threads running in thread 4, no scheduled specs, 3 leftover specs" do
       expected = []
-      write_report_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
+      write_test_distribution_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
 
       expect(Booster.new(3).select).to eq(expected)
     end
 
     it "4 threads, running in thread 1, no scheduled specs, 3 leftover specs" do
-      write_report_file('{"malformed": []}')
+      write_test_distribution_file('{"malformed": []}')
 
       expect{Booster.new(0).select}.to raise_error(StandardError)
     end
@@ -51,27 +55,32 @@ describe Semaphore::RspecBooster do
 
   def expected_specs()  Setup.expected_specs  end
 
-  context "report-file creation" do
+  describe "report-file creation" do
     before(:context) do
-      @report_file = "/tmp/rspec_report.json"
-      ENV["REPORT_PATH"] = @report_file
+      @test_distribution_file = "/tmp/rspec_file_distribution.json"
+      ENV["FILE_DISTRIBUTION_PATH"] = @test_distribution_file
     end
 
     it "runs rspec and checks for report file existence" do
       spec_dir = Setup.spec_dir()
 
-      File.delete(@report_file) if File.exist?(@report_file)
+      File.delete(@test_distribution_file) if File.exist?(@test_distribution_file)
       expect(Booster.new(0).run_command(spec_dir)).to eq(0)
       expect(File).to exist(@report_file)
     end
   end
 
-  context "script invocation" do
+  describe "script invocation" do
     before(:context) do
       @scripts = "exe"
+
+      @test_distribution_file = "/tmp/rspec_file_distribution.json"
+      ENV["RSPEC_FILE_DISTRIBUTION_PATH"] = @test_distribution_file
+
       @report_file = "/tmp/rspec_report.json"
       ENV["REPORT_PATH"] = @report_file
-      write_report_file('[{"files": []}]')
+
+      write_test_distribution_file('[{"files": []}]')
     end
 
     it "checks exit code - test fail" do
@@ -96,7 +105,7 @@ describe Semaphore::RspecBooster do
     end
   end
 
-  def write_report_file(report)
-    File.write(@report_file, report)
+  def write_test_distribution_file(report)
+    File.write(@test_distribution_file, report)
   end
 end


### PR DESCRIPTION
It is confusing if we use the same file name for the files that contain the test file distribution and the the output report of the RSpec command.

I'll try to fix this issue by doing the following:

- We use the name `#{framework}_split_configuration.json` for test file distributions
- We use the `#{framework}_report.json` for the output of rspec

Before I merge this PR, I'll make sure that Semaphore outputs the file distribution to the correct path. In the future we might solve this issue by using exported environment variables, instead of hardcoded file names.