### PR TITLE
Match class name and file name

### DIFF
--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -56,9 +56,9 @@ module Semaphore
         thread_features = all_features & thread["files"].sort
         features_to_run = thread_features + thread_leftover_features
 
-        Semaphore.display_files("This thread features:", thread_features)
-        Semaphore.display_title_and_count("All leftover features:", all_leftover_features)
-        Semaphore.display_files("This thread leftover features:", thread_leftover_features)
+        Semaphore::Logger.display_files("This thread features:", thread_features)
+        Semaphore::Logger.display_title_and_count("All leftover features:", all_leftover_features)
+        Semaphore::Logger.display_files("This thread leftover features:", thread_leftover_features)
 
         features_to_run
       end

--- a/lib/test_boosters/display_files.rb
+++ b/lib/test_boosters/display_files.rb
@@ -1,15 +1,18 @@
 module Semaphore
-  module_function
+  module Logger
+    module_function
 
-  def display_files(title, files)
-    display_title_and_count(title, files)
+    def display_files(title, files)
+      display_title_and_count(title, files)
 
-    files.each { |file| puts "- #{file}" }
+      files.each { |file| puts "- #{file}" }
 
-    puts "\n"
-  end
+      puts "\n"
+    end
 
-  def display_title_and_count(title, files)
-    puts "#{title} #{files.count}\n"
+    def display_title_and_count(title, files)
+      puts "#{title} #{files.count}\n"
+    end
+
   end
 end

--- a/lib/test_boosters/rspec_booster.rb
+++ b/lib/test_boosters/rspec_booster.rb
@@ -58,9 +58,9 @@ module Semaphore
         thread_specs = all_specs & thread["files"].sort
         specs_to_run = thread_specs + thread_leftover_specs
 
-        Semaphore.display_files("This thread specs:", thread_specs)
-        Semaphore.display_title_and_count("All leftover specs:", all_leftover_specs)
-        Semaphore.display_files("This thread leftover specs:", thread_leftover_specs)
+        Semaphore::Logger.display_files("This thread specs:", thread_specs)
+        Semaphore::Logger.display_title_and_count("All leftover specs:", all_leftover_specs)
+        Semaphore::Logger.display_files("This thread leftover specs:", thread_leftover_specs)
 
         specs_to_run
       end


### PR DESCRIPTION
In Ruby, it is a convention to match class names with file names.

Here is why:
- It enables us to jump from file to file in Vim with ease (no need to use grep to look up methods)
- It avoids issues that appear when you install Spring with hot code realoding
- It is easier to keep track where is what implemented

Ideally, this class should be called "TestBooster::Logger" to match the gem name.
I'll fix that in the next PR.