### PR TITLE
Match namespace with gem name

### DIFF
--- a/exe/cucumber_booster
+++ b/exe/cucumber_booster
@@ -2,14 +2,14 @@
 
 require "test_boosters"
 
-Semaphore::run_cucumber_config
+TestBoosters.run_cucumber_config
 
-cli_options = Semaphore::parse
+cli_options = TestBoosters.parse
 thread_index = cli_options[:index] - 1
-cucumber_booster = Semaphore::CucumberBooster.new(thread_index)
+cucumber_booster = TestBoosters::CucumberBooster.new(thread_index)
 exit_status = cucumber_booster.run
 
 report_path = cucumber_booster.report_path
-Semaphore::InsightsUploader.new.upload("cucumber", report_path)
+TestBoosters::InsightsUploader.new.upload("cucumber", report_path)
 
 exit(exit_status)

--- a/exe/rspec_booster
+++ b/exe/rspec_booster
@@ -2,12 +2,12 @@
 
 require "test_boosters"
 
-cli_options = Semaphore::parse
+cli_options = TestBoosters.parse
 thread_index = cli_options[:index] - 1
-rspec_booster = Semaphore::RspecBooster.new(thread_index)
+rspec_booster = TestBoosters::RspecBooster.new(thread_index)
 exit_status = rspec_booster.run
 
 report_path = rspec_booster.report_path
-Semaphore::InsightsUploader.new.upload("rspec", report_path)
+TestBoosters::InsightsUploader.new.upload("rspec", report_path)
 
 exit(exit_status)

--- a/lib/test_boosters/cli_parser.rb
+++ b/lib/test_boosters/cli_parser.rb
@@ -1,4 +1,4 @@
-module Semaphore
+module TestBoosters
   module_function
 
   require "optparse"

--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -1,4 +1,4 @@
-module Semaphore
+module TestBoosters
   require "json"
   require "test_boosters/cli_parser"
   require "test_boosters/logger"
@@ -39,7 +39,7 @@ module Semaphore
       puts "========================= Running Cucumber =========================="
       puts
 
-      Semaphore::execute("bundle exec cucumber #{specs}")
+      TestBoosters.execute("bundle exec cucumber #{specs}")
     end
 
     def select
@@ -52,13 +52,13 @@ module Semaphore
         all_known_features = file_distribution.map { |t| t["files"] }.flatten.sort
 
         all_leftover_features = all_features - all_known_features
-        thread_leftover_features = LeftoverFiles.select(all_leftover_features, thread_count, @thread_index)
+        thread_leftover_features = TestBoosters::LeftoverFiles.select(all_leftover_features, thread_count, @thread_index)
         thread_features = all_features & thread["files"].sort
         features_to_run = thread_features + thread_leftover_features
 
-        Semaphore::Logger.display_files("This thread features:", thread_features)
-        Semaphore::Logger.display_title_and_count("All leftover features:", all_leftover_features)
-        Semaphore::Logger.display_files("This thread leftover features:", thread_leftover_features)
+        TestBoosters::Logger.display_files("This thread features:", thread_features)
+        TestBoosters::Logger.display_title_and_count("All leftover features:", all_leftover_features)
+        TestBoosters::Logger.display_files("This thread leftover features:", thread_leftover_features)
 
         features_to_run
       end
@@ -76,7 +76,7 @@ module Semaphore
 
       error += %{Exception: #{e.message}}
 
-      Semaphore.log(error)
+      TestBoosters.log(error)
 
       raise
     end

--- a/lib/test_boosters/display_files.rb
+++ b/lib/test_boosters/display_files.rb
@@ -1,4 +1,4 @@
-module Semaphore
+module TestBoosters
   module Logger
     module_function
 

--- a/lib/test_boosters/executor.rb
+++ b/lib/test_boosters/executor.rb
@@ -1,4 +1,4 @@
-module Semaphore
+module TestBoosters
   module_function
 
   def execute(command)

--- a/lib/test_boosters/insights_uploader.rb
+++ b/lib/test_boosters/insights_uploader.rb
@@ -1,6 +1,4 @@
-module Semaphore
-  module_function
-
+module TestBoosters
   class InsightsUploader
     def initialize
       @project_hash_id = ENV["SEMAPHORE_PROJECT_UUID"]
@@ -15,7 +13,7 @@ module Semaphore
             "&project_hash_id=#{@project_hash_id}"
       cmd = "http POST '#{url}' #{booster_type}:=@#{file}"
 
-      Semaphore.execute("#{cmd} > ~/insights_uploader.log")
+      TestBoosters.execute("#{cmd} > ~/insights_uploader.log")
     end
   end
 end

--- a/lib/test_boosters/leftover_files.rb
+++ b/lib/test_boosters/leftover_files.rb
@@ -1,29 +1,30 @@
-module LeftoverFiles
-  module_function
+module TestBoosters
+  module LeftoverFiles
+    module_function
 
-  def self.select(all_leftover_files, thread_count, thread_index)
-    all_leftover_files = sort_by_size(all_leftover_files)
+    def self.select(all_leftover_files, thread_count, thread_index)
+      all_leftover_files = sort_by_size(all_leftover_files)
 
-    return [] if all_leftover_files.empty?
+      return [] if all_leftover_files.empty?
 
-    files = all_leftover_files
-      .each_slice(thread_count)
-      .reduce{ |acc, slice| acc.map{|a| a}.zip(slice.reverse) }
-      .map{ |f| f.kind_of?(Array) ? f.flatten : [f] } [thread_index]
+      files = all_leftover_files
+        .each_slice(thread_count)
+        .reduce{ |acc, slice| acc.map{|a| a}.zip(slice.reverse) }
+        .map{ |f| f.kind_of?(Array) ? f.flatten : [f] } [thread_index]
 
-    if    files.nil?            then []
-    elsif files.kind_of?(Array) then files.compact
+      if    files.nil?            then []
+      elsif files.kind_of?(Array) then files.compact
+      end
     end
+
+    def self.sort_by_size(files) # descending
+      files
+        .select { |f| File.file?(f) }
+        .map{ |f| [f, File.size(f)] }
+        .sort_by{ |a| a[1] }
+        .map{ |a| a[0] }
+        .reverse
+    end
+
   end
-
-  def self.sort_by_size(files) # descending
-    files
-      .select { |f| File.file?(f) }
-      .map{ |f| [f, File.size(f)] }
-      .sort_by{ |a| a[1] }
-      .map{ |a| a[0] }
-      .reverse
-  end
-
-
 end

--- a/lib/test_boosters/logger.rb
+++ b/lib/test_boosters/logger.rb
@@ -1,4 +1,4 @@
-module Semaphore
+module TestBoosters
   module_function
 
   def log(message)

--- a/lib/test_boosters/rspec_booster.rb
+++ b/lib/test_boosters/rspec_booster.rb
@@ -1,4 +1,4 @@
-module Semaphore
+module TestBoosters
   require "json"
   require "test_boosters/cli_parser"
   require "test_boosters/logger"
@@ -41,7 +41,7 @@ module Semaphore
       puts "========================= Running Rspec =========================="
       puts
 
-      Semaphore.execute("bundle exec rspec #{options} #{specs}")
+      TestBoosters.execute("bundle exec rspec #{options} #{specs}")
     end
 
     def select
@@ -54,13 +54,13 @@ module Semaphore
         all_known_specs = file_distribution.map { |t| t["files"] }.flatten.sort
 
         all_leftover_specs = all_specs - all_known_specs
-        thread_leftover_specs = LeftoverFiles.select(all_leftover_specs, thread_count, @thread_index)
+        thread_leftover_specs = TestBoosters::LeftoverFiles.select(all_leftover_specs, thread_count, @thread_index)
         thread_specs = all_specs & thread["files"].sort
         specs_to_run = thread_specs + thread_leftover_specs
 
-        Semaphore::Logger.display_files("This thread specs:", thread_specs)
-        Semaphore::Logger.display_title_and_count("All leftover specs:", all_leftover_specs)
-        Semaphore::Logger.display_files("This thread leftover specs:", thread_leftover_specs)
+        TestBoosters::Logger.display_files("This thread specs:", thread_specs)
+        TestBoosters::Logger.display_title_and_count("All leftover specs:", all_leftover_specs)
+        TestBoosters::Logger.display_files("This thread leftover specs:", thread_leftover_specs)
 
         specs_to_run
       end
@@ -78,7 +78,7 @@ module Semaphore
       error += %{Exception: #{e.message}\n#{e.backtrace.join("\n")}}
 
       puts error
-      Semaphore.log(error)
+      TestBoosters.log(error)
 
       raise
     end

--- a/lib/test_boosters/run_cucumber_config.rb
+++ b/lib/test_boosters/run_cucumber_config.rb
@@ -1,6 +1,6 @@
 require 'cucumber_booster_config'
 
-module Semaphore
+module TestBoosters
   module_function
 
   def run_cucumber_config()

--- a/spec/cucumber_boosters_spec.rb
+++ b/spec/cucumber_boosters_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
-CuBooster = Semaphore::CucumberBooster
-
-describe Semaphore::CucumberBooster do
+describe TestBoosters::CucumberBooster do
   describe "test select()" do
     before(:context) do
       @test_split_configuration = "/tmp/cucumber_split_configuration.json"
@@ -14,27 +12,27 @@ describe Semaphore::CucumberBooster do
       expected = [a, b]
       write_split_configuration_file('[{"files": []}, {"files": []}]')
 
-      expect(CuBooster.new(0).select).to eq(expected)
+      expect(described_class.new(0).select).to eq(expected)
     end
 
     it "2 threads running in thread 2, no scheduled specs, 3 leftover specs" do
       expected = [c]
       write_split_configuration_file('[{"files": []}, {"files": []}]')
 
-      expect(CuBooster.new(1).select).to eq(expected)
+      expect(described_class.new(1).select).to eq(expected)
     end
 
     it "4 threads running in thread 4, no scheduled specs, 3 leftover specs" do
       expected = []
       write_split_configuration_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
 
-      expect(CuBooster.new(3).select).to eq(expected)
+      expect(described_class.new(3).select).to eq(expected)
     end
 
     it "4 threads, running in thread 1, no scheduled specs, 3 leftover specs" do
       write_split_configuration_file('{"malformed": []}')
 
-      expect{CuBooster.new(0).select}.to raise_error(StandardError)
+      expect { described_class.new(0).select }.to raise_error(StandardError)
     end
   end
 
@@ -57,7 +55,7 @@ describe Semaphore::CucumberBooster do
   describe "attr_reader :report_path" do
     it "generates REPORT_PATH from HOME dir" do
       ENV["HOME"] = "/tmp"
-      booster = CuBooster.new(0)
+      booster = described_class.new(0)
       expect(booster.report_path).to eq("/tmp/rspec_report.json")
     end
   end

--- a/spec/insights_uploader_spec.rb
+++ b/spec/insights_uploader_spec.rb
@@ -1,23 +1,23 @@
 require 'spec_helper'
 
-describe Semaphore::InsightsUploader do
+describe TestBoosters::InsightsUploader do
   it "uploads dummy json file" do
     ENV["SEMAPHORE_PROJECT_UUID"]     = "not a project UUID"
     ENV["SEMAPHORE_EXECUTABLE_UUID"]  = "not a build UUID"
     ENV["SEMAPHORE_JOB_UUID"]         = "not a job UUID"
     dymmy_json_file = "spec/dymmy_json_file.json"
 
-    uploader = Semaphore::InsightsUploader.new
+    uploader = TestBoosters::InsightsUploader.new
     expect(uploader.upload("rspec", dymmy_json_file)).to eq(0)
   end
 
   it "it fails to upload dummy json file - no file" do
-    uploader = Semaphore::InsightsUploader.new
+    uploader = TestBoosters::InsightsUploader.new
     expect(uploader.upload("rspec", "no-file")).to eq(1)
   end
 
   it "it fails to upload dummy json file - malformed file" do
-    uploader = Semaphore::InsightsUploader.new
+    uploader = TestBoosters::InsightsUploader.new
     expect(uploader.upload("rspec", "README.md")).to eq(1)
   end
 

--- a/spec/leftover_files_spec.rb
+++ b/spec/leftover_files_spec.rb
@@ -1,67 +1,67 @@
 require 'spec_helper'
 
-describe LeftoverFiles do
+describe TestBoosters::LeftoverFiles do
   context "test file sorting" do
     it "tests for empty array" do
-      expect(LeftoverFiles.sort_by_size([])).to eq([])
+      expect(TestBoosters::LeftoverFiles.sort_by_size([])).to eq([])
     end
 
     it "tests single element array" do
-      expect(LeftoverFiles.sort_by_size([a])).to eq([a])
+      expect(TestBoosters::LeftoverFiles.sort_by_size([a])).to eq([a])
     end
 
     it "tests for non-existent file in array" do
-      expect(LeftoverFiles.sort_by_size(["non-existent"])).to eq([])
+      expect(TestBoosters::LeftoverFiles.sort_by_size(["non-existent"])).to eq([])
     end
 
     it "tests regular input" do
       input    = input_specs
       expected = expected_specs
-      expect(LeftoverFiles.sort_by_size(input)).to eq(expected)
+      expect(TestBoosters::LeftoverFiles.sort_by_size(input)).to eq(expected)
     end
 
     it "tests regular input with non-existent files" do
       input    = input_specs + ["non-existent"]
       expected = expected_specs
-      expect(LeftoverFiles.sort_by_size(input)).to eq(expected)
+      expect(TestBoosters::LeftoverFiles.sort_by_size(input)).to eq(expected)
     end
   end
 
   context "test select_leftover_specs()" do
     it "no leftover specs" do
-      expect(LeftoverFiles.select([], 3, 0)).to eq([])
+      expect(TestBoosters::LeftoverFiles.select([], 3, 0)).to eq([])
     end
 
     it "1 leftover spec, 3 threads, index 0" do
-      expect(LeftoverFiles.select([a], 3, 0)).to eq([a])
+      expect(TestBoosters::LeftoverFiles.select([a], 3, 0)).to eq([a])
     end
 
     it "1 leftover spec, 3 threads, index 2" do
-      expect(LeftoverFiles.select([a], 3, 2)).to eq([])
+      expect(TestBoosters::LeftoverFiles.select([a], 3, 2)).to eq([])
     end
 
     it "3 leftover specs, 2 threads, index 0" do
       input    = input_specs
       expected = [a, b]
-      expect(LeftoverFiles.select(input, 2, 0)).to eq(expected)
+      expect(TestBoosters::LeftoverFiles.select(input, 2, 0)).to eq(expected)
     end
 
     it "3 leftover specs, 2 threads, index 1" do
       input    = input_specs
       expected = [c]
-      expect(LeftoverFiles.select(input, 2, 1)).to eq(expected)
+      expect(TestBoosters::LeftoverFiles.select(input, 2, 1)).to eq(expected)
     end
 
     it "3 leftover specs, 3 threads, index 0" do
       input    = input_specs
       expected = [a]
-      expect(LeftoverFiles.select(input, 3, 0)).to eq(expected)
+      expect(TestBoosters::LeftoverFiles.select(input, 3, 0)).to eq(expected)
     end
 
     it "3 leftover specs, 3 threads, index 2" do
       input    = input_specs
       expected = [b]
-      expect(LeftoverFiles.select(input, 3, 2)).to eq(expected)
+      expect(TestBoosters::LeftoverFiles.select(input, 3, 2)).to eq(expected)
     end
   end
 

--- a/spec/rspec_booster_spec.rb
+++ b/spec/rspec_booster_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
-Booster = Semaphore::RspecBooster
-
-describe Semaphore::RspecBooster do
+describe TestBoosters::RspecBooster do
   it 'has a version number' do
     expect(TestBoosters::VERSION).not_to be nil
   end
@@ -22,27 +20,27 @@ describe Semaphore::RspecBooster do
       expected = [a, b]
       write_split_configuration_file('[{"files": []}, {"files": []}]')
 
-      expect(Booster.new(0).select).to eq(expected)
+      expect(described_class.new(0).select).to eq(expected)
     end
 
     it "2 threads running in thread 2, no scheduled specs, 3 leftover specs" do
       expected = [c]
       write_split_configuration_file('[{"files": []}, {"files": []}]')
 
-      expect(Booster.new(1).select).to eq(expected)
+      expect(described_class.new(1).select).to eq(expected)
     end
 
     it "4 threads running in thread 4, no scheduled specs, 3 leftover specs" do
       expected = []
       write_split_configuration_file('[{"files": []}, {"files": []}, {"files": []}, {"files": []}]')
 
-      expect(Booster.new(3).select).to eq(expected)
+      expect(described_class.new(3).select).to eq(expected)
     end
 
     it "4 threads, running in thread 1, no scheduled specs, 3 leftover specs" do
       write_split_configuration_file('{"malformed": []}')
 
-      expect{Booster.new(0).select}.to raise_error(StandardError)
+      expect { described_class.new(0).select }.to raise_error(StandardError)
     end
 
   end
@@ -65,7 +63,7 @@ describe Semaphore::RspecBooster do
       spec_dir = Setup.spec_dir()
 
       File.delete(@test_split_configuration) if File.exist?(@test_split_configuration)
-      expect(Booster.new(0).run_command(spec_dir)).to eq(0)
+      expect(described_class.new(0).run_command(spec_dir)).to eq(0)
       expect(File).to exist(@report_file)
     end
   end
@@ -108,14 +106,14 @@ describe Semaphore::RspecBooster do
   describe "attr_reader :report_path" do
     it "reads REPORT_PATH" do
       ENV["REPORT_PATH"] = "qwerty"
-      booster = Booster.new(0)
+      booster = described_class.new(0)
       expect(booster.report_path).to eq("qwerty")
       ENV.tap { |hs| hs.delete("REPORT_PATH") }
     end
 
     it "generates REPORT_PATH from HOME dir" do
       ENV["HOME"] = "/tmp"
-      booster = Booster.new(0)
+      booster = described_class.new(0)
       expect(booster.report_path).to eq("/tmp/rspec_report.json")
     end
   end

--- a/test_data_fail/fail_spec.rb
+++ b/test_data_fail/fail_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
-# Booster = Semaphore::RspecBooster
-
-describe Semaphore::RspecBooster do
+describe TestBoosters::RspecBooster do
   it 'fails' do
     expect(TestBoosters::VERSION).to be "wrong"
   end

--- a/test_data_pass/pass_spec.rb
+++ b/test_data_pass/pass_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Semaphore::RspecBooster do
+describe TestBoosters::RspecBooster do
   it 'passes' do
     expect(0).to eq(0)
   end


### PR DESCRIPTION
It is a convention in the Ruby world to encapsulate everything in a gem
under the gem's main module.

In essence, everything in this gem should be under the `TestBooster`
namespace, and no other root level namespace should exists (like
Semaphore and LeftoverFiles).

Here is why:
- It enables us to jump between files with ease
- It avoid accidental leakage, and clashing of namespaces

For example, if you include this gem into any other project that has the
`Semaphore` namespace, the two namespaces would collide and potentily
overload some existing modules, classes, and methods.

As a rule of thumb, and to keep everything nice and tidy, we should aim
to wrap everything into the TestBooster module.