### PR TITLE
Display which thread is executed

### DIFF
--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -69,7 +69,7 @@ module TestBoosters
 
       error += %{Exception: #{e.message}}
 
-      TestBoosters.log(error)
+      TestBoosters::Logger.error(error)
 
       raise
     end

--- a/lib/test_boosters/rspec_booster.rb
+++ b/lib/test_boosters/rspec_booster.rb
@@ -43,6 +43,8 @@ module TestBoosters
         thread_count = file_distribution.count
         thread = file_distribution[@thread_index]
 
+        puts "Running RSpec thread #{@thread_index + 1} out of #{thread_count} threads\n"
+
         all_specs = Dir["#{@spec_path}/**/*_spec.rb"].sort
         all_known_specs = file_distribution.map { |t| t["files"] }.flatten.sort
 
@@ -59,7 +61,6 @@ module TestBoosters
       end
     end
 
-
     def with_fallback
       yield
     rescue StandardError => e
@@ -71,7 +72,7 @@ module TestBoosters
       error += %{Exception: #{e.message}\n#{e.backtrace.join("\n")}}
 
       puts error
-      TestBoosters.log(error)
+      TestBoosters::Logger.error(error)
 
       raise
     end

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end


### PR DESCRIPTION
The first thing that is displayed is:

```
Running RSpec thread N out of M threads
```

* __note__: we should probably use the term Job instead of thread. We should improve and fix this in some other PR.