### PR TITLE
Introduce an abstraction for handling split configurations

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,2 +1,3 @@
-default: --format pretty  --profile semaphoreci
+default: --format pretty  --profile semaphoreci --profile semaphoreci
+semaphoreci: --format json --out=../cucumber_report.json
 semaphoreci: --format json --out=../cucumber_report.json

--- a/lib/test_boosters.rb
+++ b/lib/test_boosters.rb
@@ -5,6 +5,7 @@ require "cucumber_booster_config"
 module TestBoosters
   require "test_boosters/version"
 
+  require "test_boosters/split_configuration"
   require "test_boosters/cli_parser"
   require "test_boosters/logger"
   require "test_boosters/shell"

--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -4,6 +4,7 @@ module TestBoosters
 
     def initialize(thread_index)
       @thread_index = thread_index
+      @report_path = ENV["REPORT_PATH"] || "#{ENV["HOME"]}/cucumber_report.json"
       @spec_path = ENV["SPEC_PATH"] || "features"
     end
 

--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -4,8 +4,6 @@ module TestBoosters
 
     def initialize(thread_index)
       @thread_index = thread_index
-      @cucumber_split_configuration_path = ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] || "#{ENV["HOME"]}/cucumber_split_configuration.json"
-      @report_path = "#{ENV["HOME"]}/rspec_report.json"
       @spec_path = ENV["SPEC_PATH"] || "features"
     end
 
@@ -37,16 +35,15 @@ module TestBoosters
 
     def select
       with_fallback do
-        file_distribution = JSON.parse(File.read(@cucumber_split_configuration_path))
-        thread_count = file_distribution.count
-        thread = file_distribution[@thread_index]
+        split_configuration = TestBoosters::SplitConfiguration.for_cucumber
+        thread_count = split_configuration.threads.count
 
         all_features = Dir["#{@spec_path}/**/*.feature"].sort
-        all_known_features = file_distribution.map { |t| t["files"] }.flatten.sort
+        all_known_features = split_configuration.all_files
 
         all_leftover_features = all_features - all_known_features
         thread_leftover_features = TestBoosters::LeftoverFiles.select(all_leftover_features, thread_count, @thread_index)
-        thread_features = all_features & thread["files"].sort
+        thread_features = all_features & split_configuration.files_for_thread(@thread_index)
         features_to_run = thread_features + thread_leftover_features
 
         TestBoosters::Shell.display_files("This thread features:", thread_features)

--- a/lib/test_boosters/rspec_booster.rb
+++ b/lib/test_boosters/rspec_booster.rb
@@ -4,7 +4,6 @@ module TestBoosters
 
     def initialize(thread_index)
       @thread_index = thread_index
-      @rspec_split_configuration_path = ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] || "#{ENV["HOME"]}/rspec_split_configuration.json"
       @report_path = ENV["REPORT_PATH"] || "#{ENV["HOME"]}/rspec_report.json"
       @spec_path = ENV["SPEC_PATH"] || "spec"
     end
@@ -39,18 +38,18 @@ module TestBoosters
 
     def select
       with_fallback do
-        file_distribution = JSON.parse(File.read(@rspec_split_configuration_path))
-        thread_count = file_distribution.count
-        thread = file_distribution[@thread_index]
+        split_configuration = TestBoosters::SplitConfiguration.for_rspec
+        thread_count = split_configuration.threads.count
 
         puts "Running RSpec thread #{@thread_index + 1} out of #{thread_count} threads\n"
 
         all_specs = Dir["#{@spec_path}/**/*_spec.rb"].sort
-        all_known_specs = file_distribution.map { |t| t["files"] }.flatten.sort
+        all_known_specs = split_configuration.all_files
 
         all_leftover_specs = all_specs - all_known_specs
         thread_leftover_specs = TestBoosters::LeftoverFiles.select(all_leftover_specs, thread_count, @thread_index)
-        thread_specs = all_specs & thread["files"].sort
+
+        thread_specs = all_specs & split_configuration.files_for_thread(@thread_index)
         specs_to_run = thread_specs + thread_leftover_specs
 
         TestBoosters::Shell.display_files("This thread specs:", thread_specs)

--- a/lib/test_boosters/split_configuration.rb
+++ b/lib/test_boosters/split_configuration.rb
@@ -1,13 +1,21 @@
 module TestBoosters
   class SplitConfiguration
 
-    class Thread < Struct.new(:files, :thread_index)
+    def self.for_rspec
+      path_from_env = ENV["RSPEC_SPLIT_CONFIGURATION_PATH"]
+      default_path = "#{ENV["HOME"]}/rspec_split_configuration.json"
+
+      new(path_from_env || default_path)
     end
 
-    def self.for_rspec
-      path = ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] || "#{ENV["HOME"]}/rspec_split_configuration.json"
+    def self.for_cucumber
+      path_from_env = ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"]
+      default_path = "#{ENV["HOME"]}/cucumber_split_configuration.json"
 
-      new(path)
+      new(path_from_env || default_path)
+    end
+
+    class Thread < Struct.new(:files, :thread_index)
     end
 
     def initialize(path)
@@ -27,7 +35,7 @@ module TestBoosters
     end
 
     def threads
-      @thread ||= load_data.map.with_index do |raw_thread, index|
+      @threads ||= load_data.map.with_index do |raw_thread, index|
         TestBoosters::SplitConfiguration::Thread.new(raw_thread["files"].sort, index)
       end
     end

--- a/lib/test_boosters/split_configuration.rb
+++ b/lib/test_boosters/split_configuration.rb
@@ -1,0 +1,46 @@
+module TestBoosters
+  class SplitConfiguration
+
+    class Thread < Struct.new(:files, :thread_index)
+    end
+
+    def self.for_rspec
+      path = ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] || "#{ENV["HOME"]}/rspec_split_configuration.json"
+
+      new(path)
+    end
+
+    def initialize(path)
+      @path = path
+    end
+
+    def present?
+      File.exist?(@path)
+    end
+
+    def all_files
+      @all_files ||= threads.map(&:files).flatten.sort
+    end
+
+    def files_for_thread(thread_index)
+      threads[thread_index].files
+    end
+
+    def threads
+      @thread ||= load_data.map.with_index do |raw_thread, index|
+        TestBoosters::SplitConfiguration::Thread.new(raw_thread["files"].sort, index)
+      end
+    end
+
+    private
+
+    def load_data
+      if present?
+        JSON.parse(File.read(@path))
+      else
+        []
+      end
+    end
+
+  end
+end

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "1.2.4"
+  VERSION = "1.3.0"
 end

--- a/spec/lib/test_boosters/cucumber_booster_spec.rb
+++ b/spec/lib/test_boosters/cucumber_booster_spec.rb
@@ -52,14 +52,6 @@ describe TestBoosters::CucumberBooster do
     end
   end
 
-  describe "attr_reader :report_path" do
-    it "generates REPORT_PATH from HOME dir" do
-      ENV["HOME"] = "/tmp"
-      booster = described_class.new(0)
-      expect(booster.report_path).to eq("/tmp/rspec_report.json")
-    end
-  end
-
   def write_split_configuration_file(report)
     File.write(@test_split_configuration, report)
   end

--- a/spec/lib/test_boosters/cucumber_booster_spec.rb
+++ b/spec/lib/test_boosters/cucumber_booster_spec.rb
@@ -52,6 +52,28 @@ describe TestBoosters::CucumberBooster do
     end
   end
 
+  describe "#report_path" do
+    context "REPORT_PATH env variable is present" do
+      it "reads the content of the env variable" do
+        ENV["REPORT_PATH"] = "qwerty"
+
+        booster = described_class.new(0)
+
+        expect(booster.report_path).to eq("qwerty")
+
+        ENV.delete("REPORT_PATH")
+      end
+    end
+
+    context "REPORT_PATH does not exists" do
+      it "generates path from HOME dir" do
+        ENV["HOME"] = "/tmp"
+        booster = described_class.new(0)
+        expect(booster.report_path).to eq("/tmp/cucumber_report.json")
+      end
+    end
+  end
+
   def write_split_configuration_file(report)
     File.write(@test_split_configuration, report)
   end

--- a/spec/lib/test_boosters/split_configuration_spec.rb
+++ b/spec/lib/test_boosters/split_configuration_spec.rb
@@ -22,6 +22,26 @@ describe TestBoosters::SplitConfiguration do
     end
   end
 
+  describe ".for_cucumber" do
+    context "env var points to file location" do
+      before do
+        content = [ { :files => ["dragon_ball_z.feature"] } ]
+
+        @path = "/tmp/split_configuration"
+
+        ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] = @path
+
+        File.write(@path, content.to_json)
+      end
+
+      subject { TestBoosters::SplitConfiguration.new(@path) }
+
+      it "loads from the file pointed by the env var" do
+        expect(subject.all_files).to include("dragon_ball_z.feature")
+      end
+    end
+  end
+
   context "file does not exists" do
     subject { TestBoosters::SplitConfiguration.new("/tmp/non_existing_file_path") }
 

--- a/spec/lib/test_boosters/split_configuration_spec.rb
+++ b/spec/lib/test_boosters/split_configuration_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+describe TestBoosters::SplitConfiguration do
+
+  describe ".for_rspec" do
+    context "env var points to file location" do
+      before do
+        content = [ { :files => ["dragon_ball_z_spec.rb"] } ]
+
+        @path = "/tmp/split_configuration"
+
+        ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = @path
+
+        File.write(@path, content.to_json)
+      end
+
+      subject { TestBoosters::SplitConfiguration.new(@path) }
+
+      it "loads from the file pointed by the env var" do
+        expect(subject.all_files).to include("dragon_ball_z_spec.rb")
+      end
+    end
+  end
+
+  context "file does not exists" do
+    subject { TestBoosters::SplitConfiguration.new("/tmp/non_existing_file_path") }
+
+    it { is_expected.to_not be_present }
+
+    describe "#all_files" do
+      it "should be an empty array" do
+        expect(subject.all_files).to eq([])
+      end
+    end
+
+    describe "#threads" do
+      it "should be an empty array" do
+        expect(subject.threads).to eq([])
+      end
+    end
+  end
+
+  context "file is present on the disk" do
+    before do
+      content = [
+        { :files => ["a_spec.rb", "d_spec.rb", "c_spec.rb"] },
+        { :files => ["f_spec.rb", "b_spec.rb"] },
+        { :files => [] },
+      ]
+
+      @path = "/tmp/split_configuration"
+
+      File.write(@path, content.to_json)
+    end
+
+    subject { TestBoosters::SplitConfiguration.new(@path) }
+
+    it { is_expected.to be_present }
+
+    describe "#all_files" do
+      it "should return all files from the split configuration" do
+        expect(subject.all_files).to eq([
+          "a_spec.rb",
+          "b_spec.rb",
+          "c_spec.rb",
+          "d_spec.rb",
+          "f_spec.rb",
+        ])
+      end
+    end
+
+    describe "#threads" do
+      it "returns instances of TestBoosters::SplitConfiguration::Thread" do
+        subject.threads.each do |thread|
+          expect(thread).to be_instance_of(TestBoosters::SplitConfiguration::Thread)
+        end
+      end
+
+      it "puts every file to its proper thread instance" do
+        expect(subject.threads[0].files).to eq ["a_spec.rb", "c_spec.rb", "d_spec.rb"]
+        expect(subject.threads[1].files).to eq ["b_spec.rb", "f_spec.rb"]
+        expect(subject.threads[2].files).to eq []
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
By introducing a dedicated class that manages the split configuration
file, it is easier to write unit tests, and it also provides better
clarity while calculating what files need to be executed.

In short:

For rspec, you can use:

``` ruby
split_configuration = TestBoosters::SplitConfiguration.for_rspec

split_configuration.all_files            # => ["a_spec.rb", "b_spec.rb"]
split_configuration.files_for_thread(2)  # => ["a_spec.rb"]
split_configuration.threads.count        # => returns number of threads in the file

split_configuration.threads.first.files  # read files from the first threads
```

For cucumber, you can use:

``` ruby
split_configuration = TestBoosters::SplitConfiguration.for_cucumber
```