### PR TITLE
Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 require: rubocop-rspec
 
+AllCops:
+  Exclude:
+    - "lib/test_boosters/rspec_booster.rb"
+    - "lib/test_boosters/cucumber_booster.rb"
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
@@ -31,3 +36,9 @@ Style/EmptyLinesAroundModuleBody:
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: indented
   IndentationWidth: 2
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_perl_names
+
+Style/PercentLiteralDelimiters:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,20 @@
+require: rubocop-rspec
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+Style/CollectionMethods:
+  StyleGuide: "https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size"
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,7 @@ Style/EmptyLinesAroundClassBody:
 
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  IndentationWidth: 2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Style/HashSyntax:
 Style/CollectionMethods:
   StyleGuide: "https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size"
   Enabled: true
+
+Metrics/LineLength:
+  Max: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
 require: rubocop-rspec
 
 AllCops:
+  DisplayCopNames: true
+
   Exclude:
     - "vendor/**/*"
     - "lib/test_boosters/rspec_booster.rb"
@@ -48,4 +50,19 @@ Style/PercentLiteralDelimiters:
   Enabled: false
 
 RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Max: 5
+
+Metrics/BlockLength:
+  Exclude:
+    - "Rakefile"
+    - "**/*.rake"
+    - "spec/**/*.rb"
+
+Style/EmptyLinesAroundBlockBody:
+  Enabled: false
+
+RSpec/BeforeAfterAll:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,7 +44,7 @@ Style/MultilineMethodCallIndentation:
   IndentationWidth: 2
 
 Style/SpecialGlobalVars:
-  EnforcedStyle: use_perl_names
+  Enabled: false
 
 Style/PercentLiteralDelimiters:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,3 +66,6 @@ Style/EmptyLinesAroundBlockBody:
 
 RSpec/BeforeAfterAll:
   Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,9 @@ RSpec/BeforeAfterAll:
 
 RSpec/ExampleLength:
   Enabled: false
+
+RSpec/DescribedClass:
+  Enabled: false
+
+Style/IndentArray:
+  EnforcedStyle: consistent

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   DisplayCopNames: true
 
   Exclude:
+    - "*.gemspec"
     - "vendor/**/*"
     - "lib/test_boosters/rspec_booster.rb"
     - "lib/test_boosters/cucumber_booster.rb"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,9 @@ Style/CollectionMethods:
 
 Metrics/LineLength:
   Max: 120
+
+Style/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Style/EmptyLinesAroundModuleBody:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,12 @@ require: rubocop-rspec
 
 AllCops:
   Exclude:
+    - "vendor/**/*"
     - "lib/test_boosters/rspec_booster.rb"
     - "lib/test_boosters/cucumber_booster.rb"
+    - "lib/test_boosters/insights_uploader.rb"
+    - "test_data_pass/**/*"
+    - "test_data_fail/**/*"
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -41,4 +45,7 @@ Style/SpecialGlobalVars:
   EnforcedStyle: use_perl_names
 
 Style/PercentLiteralDelimiters:
+  Enabled: false
+
+RSpec/InstanceVariable:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in test_boosters.gemspec
 gemspec

--- a/lib/test_boosters.rb
+++ b/lib/test_boosters.rb
@@ -24,5 +24,4 @@ module TestBoosters
 
     CucumberBoosterConfig::CLI.start ["inject", "."]
   end
-
 end

--- a/lib/test_boosters/cucumber_booster.rb
+++ b/lib/test_boosters/cucumber_booster.rb
@@ -18,7 +18,7 @@ module TestBoosters
         else
           exit_code = run_command(features_to_run.join(" "))
         end
-      rescue StandardError => e
+      rescue StandardError
         if @thread_index == 0
           exit_code = run_command(@spec_path)
         end
@@ -65,7 +65,7 @@ module TestBoosters
 
       puts error
 
-      error += %{Exception: #{e.message}}
+      error += "Exception: #{e.message}"
 
       TestBoosters::Logger.error(error)
 

--- a/lib/test_boosters/leftover_files.rb
+++ b/lib/test_boosters/leftover_files.rb
@@ -9,11 +9,11 @@ module TestBoosters
 
       files = all_leftover_files
         .each_slice(thread_count)
-        .reduce{ |acc, slice| acc.map{|a| a}.zip(slice.reverse) }
-        .map{ |f| f.kind_of?(Array) ? f.flatten : [f] } [thread_index]
+        .reduce { |acc, slice| acc.map { |a| a }.zip(slice.reverse) }
+        .map { |f| f.is_a?(Array) ? f.flatten : [f] } [thread_index]
 
       if    files.nil?            then []
-      elsif files.kind_of?(Array) then files.compact
+      elsif files.is_a?(Array) then files.compact
       end
     end
 

--- a/lib/test_boosters/split_configuration.rb
+++ b/lib/test_boosters/split_configuration.rb
@@ -1,6 +1,8 @@
 module TestBoosters
   class SplitConfiguration
 
+    Thread = Struct.new(:files, :thread_index)
+
     def self.for_rspec
       path_from_env = ENV["RSPEC_SPLIT_CONFIGURATION_PATH"]
       default_path = "#{ENV["HOME"]}/rspec_split_configuration.json"
@@ -13,9 +15,6 @@ module TestBoosters
       default_path = "#{ENV["HOME"]}/cucumber_split_configuration.json"
 
       new(path_from_env || default_path)
-    end
-
-    class Thread < Struct.new(:files, :thread_index)
     end
 
     def initialize(path)

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "1.3.0"
+  VERSION = "1.3.0".freeze
 end

--- a/spec/lib/test_boosters/cucumber_booster_spec.rb
+++ b/spec/lib/test_boosters/cucumber_booster_spec.rb
@@ -1,11 +1,11 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe TestBoosters::CucumberBooster do
   describe "test select()" do
     before(:context) do
       @test_split_configuration = "/tmp/cucumber_split_configuration.json"
       ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] = @test_split_configuration
-      ENV["SPEC_PATH"]   = "test_data"
+      ENV["SPEC_PATH"] = "test_data"
     end
 
     it "2 threads running in thread 1, no scheduled specs, 3 leftover specs" do
@@ -78,11 +78,23 @@ describe TestBoosters::CucumberBooster do
     File.write(@test_split_configuration, report)
   end
 
-  def a() Setup::Cucumber.a end
-  def b() Setup::Cucumber.b end
-  def c() Setup::Cucumber.c end
+  def a
+    Setup::Cucumber.a
+  end
 
-  def input_specs() Setup::Cucumber.input_specs  end
+  def b
+    Setup::Cucumber.b
+  end
 
-  def expected_specs()  Setup::Cucumber.expected_specs  end
+  def c
+    Setup::Cucumber.c
+  end
+
+  def input_specs
+    Setup::Cucumber.input_specs
+  end
+
+  def expected_specs
+    Setup::Cucumber.expected_specs
+  end
 end

--- a/spec/lib/test_boosters/insights_uploader_spec.rb
+++ b/spec/lib/test_boosters/insights_uploader_spec.rb
@@ -1,6 +1,7 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe TestBoosters::InsightsUploader do
+
   it "uploads dummy json file" do
     ENV["SEMAPHORE_PROJECT_UUID"]     = "not a project UUID"
     ENV["SEMAPHORE_EXECUTABLE_UUID"]  = "not a build UUID"
@@ -11,12 +12,12 @@ describe TestBoosters::InsightsUploader do
     expect(uploader.upload("rspec", dymmy_json_file)).to eq(0)
   end
 
-  it "it fails to upload dummy json file - no file" do
+  it "fails to upload dummy json file - no file" do
     uploader = described_class.new
     expect(uploader.upload("rspec", "no-file")).to eq(1)
   end
 
-  it "it fails to upload dummy json file - malformed file" do
+  it "fails to upload dummy json file - malformed file" do
     uploader = described_class.new
     expect(uploader.upload("rspec", "README.md")).to eq(1)
   end

--- a/spec/lib/test_boosters/insights_uploader_spec.rb
+++ b/spec/lib/test_boosters/insights_uploader_spec.rb
@@ -7,17 +7,17 @@ describe TestBoosters::InsightsUploader do
     ENV["SEMAPHORE_JOB_UUID"]         = "not a job UUID"
     dymmy_json_file = "spec/dymmy_json_file.json"
 
-    uploader = TestBoosters::InsightsUploader.new
+    uploader = described_class.new
     expect(uploader.upload("rspec", dymmy_json_file)).to eq(0)
   end
 
   it "it fails to upload dummy json file - no file" do
-    uploader = TestBoosters::InsightsUploader.new
+    uploader = described_class.new
     expect(uploader.upload("rspec", "no-file")).to eq(1)
   end
 
   it "it fails to upload dummy json file - malformed file" do
-    uploader = TestBoosters::InsightsUploader.new
+    uploader = described_class.new
     expect(uploader.upload("rspec", "README.md")).to eq(1)
   end
 

--- a/spec/lib/test_boosters/leftover_files_spec.rb
+++ b/spec/lib/test_boosters/leftover_files_spec.rb
@@ -53,35 +53,48 @@ describe TestBoosters::LeftoverFiles do
     end
 
     it "3 leftover specs, 2 threads, index 0" do
-      input    = input_specs
+      input = input_specs
       expected = [a, b]
       expect(TestBoosters::LeftoverFiles.select(input, 2, 0)).to eq(expected)
     end
 
     it "3 leftover specs, 2 threads, index 1" do
-      input    = input_specs
+      input = input_specs
       expected = [c]
       expect(TestBoosters::LeftoverFiles.select(input, 2, 1)).to eq(expected)
     end
 
     it "3 leftover specs, 3 threads, index 0" do
-      input    = input_specs
+      input = input_specs
       expected = [a]
       expect(TestBoosters::LeftoverFiles.select(input, 3, 0)).to eq(expected)
     end
 
     it "3 leftover specs, 3 threads, index 2" do
-      input    = input_specs
+      input = input_specs
       expected = [b]
       expect(TestBoosters::LeftoverFiles.select(input, 3, 2)).to eq(expected)
     end
   end
 
-  def a() Setup.a end
-  def b() Setup.b end
-  def c() Setup.c end
+  def a
+    Setup.a
+  end
 
-  def input_specs() Setup.input_specs  end
+  def b
+    Setup.b
+  end
 
-  def expected_specs()  Setup.expected_specs  end
+  def c
+    Setup.c
+  end
+
+  def input_specs
+    Setup.input_specs
+  end
+
+  def expected_specs
+    Setup.expected_specs
+  end
+
 end

--- a/spec/lib/test_boosters/rspec_booster_spec.rb
+++ b/spec/lib/test_boosters/rspec_booster_spec.rb
@@ -9,7 +9,7 @@ describe TestBoosters::RspecBooster do
     before(:context) do
       @test_split_configuration = "/tmp/rspec_split_configuration.json"
       ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = @test_split_configuration
-      ENV["SPEC_PATH"] = Setup.spec_dir()
+      ENV["SPEC_PATH"] = Setup.spec_dir
     end
 
     it "2 threads running in thread 1, no scheduled specs, 3 leftover specs" do
@@ -41,13 +41,25 @@ describe TestBoosters::RspecBooster do
 
   end
 
-  def a() Setup.a end
-  def b() Setup.b end
-  def c() Setup.c end
+  def a
+    Setup.a
+  end
 
-  def input_specs() Setup.input_specs  end
+  def b
+    Setup.b
+  end
 
-  def expected_specs()  Setup.expected_specs  end
+  def c
+    Setup.c
+  end
+
+  def input_specs
+    Setup.input_specs
+  end
+
+  def expected_specs
+    Setup.expected_specs
+  end
 
   describe "report-file creation" do
     before(:context) do

--- a/spec/lib/test_boosters/split_configuration_spec.rb
+++ b/spec/lib/test_boosters/split_configuration_spec.rb
@@ -5,7 +5,7 @@ describe TestBoosters::SplitConfiguration do
   describe ".for_rspec" do
     context "env var points to file location" do
       before do
-        content = [ { :files => ["dragon_ball_z_spec.rb"] } ]
+        content = [{ :files => ["dragon_ball_z_spec.rb"] }]
 
         @path = "/tmp/split_configuration"
 
@@ -14,10 +14,10 @@ describe TestBoosters::SplitConfiguration do
         File.write(@path, content.to_json)
       end
 
-      subject { TestBoosters::SplitConfiguration.new(@path) }
+      subject(:configuration) { TestBoosters::SplitConfiguration.new(@path) }
 
       it "loads from the file pointed by the env var" do
-        expect(subject.all_files).to include("dragon_ball_z_spec.rb")
+        expect(configuration.all_files).to include("dragon_ball_z_spec.rb")
       end
     end
   end
@@ -25,7 +25,7 @@ describe TestBoosters::SplitConfiguration do
   describe ".for_cucumber" do
     context "env var points to file location" do
       before do
-        content = [ { :files => ["dragon_ball_z.feature"] } ]
+        content = [{ :files => ["dragon_ball_z.feature"] }]
 
         @path = "/tmp/split_configuration"
 
@@ -34,28 +34,28 @@ describe TestBoosters::SplitConfiguration do
         File.write(@path, content.to_json)
       end
 
-      subject { TestBoosters::SplitConfiguration.new(@path) }
+      subject(:configuration) { TestBoosters::SplitConfiguration.new(@path) }
 
       it "loads from the file pointed by the env var" do
-        expect(subject.all_files).to include("dragon_ball_z.feature")
+        expect(configuration.all_files).to include("dragon_ball_z.feature")
       end
     end
   end
 
   context "file does not exists" do
-    subject { TestBoosters::SplitConfiguration.new("/tmp/non_existing_file_path") }
+    subject(:configuration) { TestBoosters::SplitConfiguration.new("/tmp/non_existing_file_path") }
 
-    it { is_expected.to_not be_present }
+    it { is_expected.not_to be_present }
 
     describe "#all_files" do
-      it "should be an empty array" do
-        expect(subject.all_files).to eq([])
+      it "is an empty array" do
+        expect(configuration.all_files).to eq([])
       end
     end
 
     describe "#threads" do
-      it "should be an empty array" do
-        expect(subject.threads).to eq([])
+      it "is an empty array" do
+        expect(configuration.threads).to eq([])
       end
     end
   end
@@ -65,7 +65,7 @@ describe TestBoosters::SplitConfiguration do
       content = [
         { :files => ["a_spec.rb", "d_spec.rb", "c_spec.rb"] },
         { :files => ["f_spec.rb", "b_spec.rb"] },
-        { :files => [] },
+        { :files => [] }
       ]
 
       @path = "/tmp/split_configuration"
@@ -73,33 +73,33 @@ describe TestBoosters::SplitConfiguration do
       File.write(@path, content.to_json)
     end
 
-    subject { TestBoosters::SplitConfiguration.new(@path) }
+    subject(:configuration) { TestBoosters::SplitConfiguration.new(@path) }
 
     it { is_expected.to be_present }
 
     describe "#all_files" do
-      it "should return all files from the split configuration" do
-        expect(subject.all_files).to eq([
+      it "returns all files from the split configuration" do
+        expect(configuration.all_files).to eq([
           "a_spec.rb",
           "b_spec.rb",
           "c_spec.rb",
           "d_spec.rb",
-          "f_spec.rb",
+          "f_spec.rb"
         ])
       end
     end
 
     describe "#threads" do
       it "returns instances of TestBoosters::SplitConfiguration::Thread" do
-        subject.threads.each do |thread|
+        configuration.threads.each do |thread|
           expect(thread).to be_instance_of(TestBoosters::SplitConfiguration::Thread)
         end
       end
 
       it "puts every file to its proper thread instance" do
-        expect(subject.threads[0].files).to eq ["a_spec.rb", "c_spec.rb", "d_spec.rb"]
-        expect(subject.threads[1].files).to eq ["b_spec.rb", "f_spec.rb"]
-        expect(subject.threads[2].files).to eq []
+        expect(configuration.threads[0].files).to eq ["a_spec.rb", "c_spec.rb", "d_spec.rb"]
+        expect(configuration.threads[1].files).to eq ["b_spec.rb", "f_spec.rb"]
+        expect(configuration.threads[2].files).to eq []
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,30 +1,59 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'test_boosters'
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "test_boosters"
 
 module Setup
   module_function
 
-  def spec_dir() "test_data" end
+  def spec_dir
+    "test_data"
+  end
 
-  def a() "test_data/a_spec.rb" end
-  def b() "test_data/b_spec.rb" end
-  def c() "test_data/c_spec.rb" end
+  def a
+    "test_data/a_spec.rb"
+  end
 
-  def input_specs()     [a, b, c]  end
+  def b
+    "test_data/b_spec.rb"
+  end
 
-  def expected_specs()  [a, c, b]  end
+  def c
+    "test_data/c_spec.rb"
+  end
+
+  def input_specs
+    [a, b, c]
+  end
+
+  def expected_specs
+    [a, c, b]
+  end
 
   module Cucumber
     module_function
 
-    def feature_dir() "test_data" end
+    def feature_dir
+      "test_data"
+    end
 
-    def a() "test_data/a.feature" end
-    def b() "test_data/b.feature" end
-    def c() "test_data/c.feature" end
+    def a
+      "test_data/a.feature"
+    end
 
-    def input_specs()     [a, b, c]  end
+    def b
+      "test_data/b.feature"
+    end
 
-    def expected_specs()  [a, c, b]  end
+    def c
+      "test_data/c.feature"
+    end
+
+    def input_specs
+      [a, b, c]
+    end
+
+    def expected_specs
+      [a, c, b]
+    end
+
   end
 end

--- a/test_boosters.gemspec
+++ b/test_boosters.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cucumber-rails", "~> 1.4.3"
 
   spec.add_development_dependency "rubocop", "~> 0.47.1"
+  spec.add_development_dependency "rubocop-rspec", "~> 1.13.0"
 end

--- a/test_boosters.gemspec
+++ b/test_boosters.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "activesupport", "~> 4.0"
   spec.add_development_dependency "cucumber-rails", "~> 1.4.3"
+
+  spec.add_development_dependency "rubocop", "~> 0.47.1"
 end


### PR DESCRIPTION
Rubocop is one of the best tools to maintain the health of the code
base. We at @renderedtext, use it for most of our Ruby based projects.

Notes on changes:

- We have several methods called `a`, `b`, `c` and they return constants. Not sure if this is a good practice. It is also a bit hard to follow what they refer to. We should improve this in the next PR.

- I have ignored some files like `rspec_booster` and `cucumber_booster` out of the rubocop checks. It is bit hard to fix them in this PR. I'll try to open separate pull requests for fixing them.