### PR TITLE
Custom RSpec options for RSpec Booster

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ By default, `rspec_booster` passes the following options to RSpec:
 ```
 
 If you want to pass additional parameters to RSpec, you can do that by setting
-the `RSPEC_OPTIONS` environment variable.
+the `TB_RSPEC_OPTIONS` environment variable.
 
 For example, if you want to pass a `--fail-fast` option to RSpec, you can do it
 like this:
 
 ``` bash
-export RSPEC_OPTIONS = '--fail-fast'
+export TB_RSPEC_OPTIONS = '--fail-fast'
 
 rspec_booster --thread 2
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,94 @@ gem install test_boosters
 
 ## Usage
 
-TODO: Write usage instructions here
+### RSpec Booster
+
+The RSpec booster command allows you to run one out of several parallel rspec
+threads.
+
+``` bash
+rspec_booster --thread 3
+```
+
+#### RSpec Split Configuration
+
+The `rspec_split_configuration.json` located in your home directory is used to
+pass test files to the booster. On Semaphore, this file contains a list of
+specs files distributed across threads based on their estimated durations.
+
+For example, if you have a `rspec_split_configuration.json` located in your home
+directory with the following content:
+
+``` json
+[
+  { :files => ["spec/a_spec.rb", "spec/b_spec.rb"] },
+  { :files => ["spec/c_spec.rb", "spec/d_spec.rb"] },
+  { :files => ["spec/e_spec.rb"] }
+]
+```
+
+The `rspec_booster` command will deduce that you have 3 threads in total and
+that you want to run `spec/a_spec.rb` and `spec/b_spec.rb` on the first thread,
+`spec/c_spec.rb` and `spec/d_spec.rb` on the second thread, and `spec/e_spec.rb`
+on the third thread.
+
+#### Leftover files
+
+The RSpec Split Configuration contains only those spec files that have an
+estimated duration recorded on Semaphore. New files, whose estimated duration
+is not yet stored on Semaphore will be distributed across threads in based on
+their file size in a round robin fashion.
+
+For example, if you have the following split configuration:
+
+``` json
+[
+  { :files => ["spec/a_spec.rb"] }
+  { :files => ["spec/b_spec.rb"] }
+  { :files => ["spec/c_spec.rb"] }
+]
+```
+
+and the following files in your spec directory:
+
+``` bash
+spec/a_spec.rb
+spec/b_spec.rb
+spec/c_spec.rb
+spec/d_spec.rb
+spec/e_spec.rb
+```
+
+When you run the `rspec_booster --thread 1` command, the files from the
+configuration's first thread and some leftover files will be executed.
+
+``` bash
+rspec_booster --thread 1
+
+# => runs: bundle exec rspec spec/a_spec.rb spec/d_spec.rb
+```
+
+#### Custom RSpec options
+
+By default, `rspec_booster` passes the following options to RSpec:
+
+``` bash
+--format documentation --format json --out ~/rspec_report.json
+```
+
+If you want to pass additional parameters to RSpec, you can do that by setting
+the `RSPEC_OPTIONS` environment variable.
+
+For example, if you want to pass a `--fail-fast` option to RSpec, you can do it
+like this:
+
+``` bash
+export RSPEC_OPTIONS = '--fail-fast'
+
+rspec_booster --thread 2
+
+# => runs: bundle exec rspec --fail-fast --format documentation --format json --out ~/rspec_report.json <file_list>
+```
 
 ## Contributing
 

--- a/lib/test_boosters/rspec/thread.rb
+++ b/lib/test_boosters/rspec/thread.rb
@@ -53,7 +53,7 @@ module TestBoosters
       end
 
       def rspec_options
-        "--format documentation --format json --out #{report_path}"
+        "#{ENV["RSPEC_OPTIONS"]} --format documentation --format json --out #{report_path}"
       end
 
       def rspec_command

--- a/lib/test_boosters/rspec/thread.rb
+++ b/lib/test_boosters/rspec/thread.rb
@@ -53,7 +53,7 @@ module TestBoosters
       end
 
       def rspec_options
-        "#{ENV["RSPEC_OPTIONS"]} --format documentation --format json --out #{report_path}"
+        "#{ENV["TB_RSPEC_OPTIONS"]} --format documentation --format json --out #{report_path}"
       end
 
       def rspec_command

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "1.4.5".freeze
+  VERSION = "1.5.0".freeze
 end

--- a/spec/lib/test_boosters/rspec/thread_spec.rb
+++ b/spec/lib/test_boosters/rspec/thread_spec.rb
@@ -52,7 +52,7 @@ describe TestBoosters::Rspec::Thread do
 
     it "executes the rspec command" do
       files = "#{files_from_split_config.join(" ")} #{leftover_files.join(" ")}"
-      options = "--format documentation --format json --out #{report_path}"
+      options = " --format documentation --format json --out #{report_path}"
       cmd = "bundle exec rspec #{options} #{files}"
 
       expect(TestBoosters::Shell).to receive(:execute).with(cmd)
@@ -74,6 +74,25 @@ describe TestBoosters::Rspec::Thread do
 
     it "displays rspec options" do
       expect { thread.display_thread_info }.to output(/#{thread.rspec_options}/).to_stdout
+    end
+  end
+
+  describe "#rspec_options" do
+    subject(:thread) { TestBoosters::Rspec::Thread.new(files_from_split_config, leftover_files) }
+
+    context "when RSPEC_OPTIONS env variable is empty" do
+      it "returns the default options" do
+        expect(thread.rspec_options).to eq(" --format documentation --format json --out /tmp/rspec_report.json")
+      end
+    end
+
+    context "when RSPEC_OPTIONS env variable is present" do
+      before { ENV["RSPEC_OPTIONS"] = "--fail-fast=3" }
+      after  { ENV.delete("RSPEC_OPTIONS") }
+
+      it "returns the default options with the environment variable content" do
+        expect(thread.rspec_options).to eq("--fail-fast=3 --format documentation --format json --out /tmp/rspec_report.json")
+      end
     end
   end
 

--- a/spec/lib/test_boosters/rspec/thread_spec.rb
+++ b/spec/lib/test_boosters/rspec/thread_spec.rb
@@ -90,8 +90,10 @@ describe TestBoosters::Rspec::Thread do
       before { ENV["RSPEC_OPTIONS"] = "--fail-fast=3" }
       after  { ENV.delete("RSPEC_OPTIONS") }
 
+      subject(:options) { thread.rspec_options }
+
       it "returns the default options with the environment variable content" do
-        expect(thread.rspec_options).to eq("--fail-fast=3 --format documentation --format json --out /tmp/rspec_report.json")
+        expect(options).to eq("--fail-fast=3 --format documentation --format json --out /tmp/rspec_report.json")
       end
     end
   end

--- a/spec/lib/test_boosters/rspec/thread_spec.rb
+++ b/spec/lib/test_boosters/rspec/thread_spec.rb
@@ -80,15 +80,15 @@ describe TestBoosters::Rspec::Thread do
   describe "#rspec_options" do
     subject(:thread) { TestBoosters::Rspec::Thread.new(files_from_split_config, leftover_files) }
 
-    context "when RSPEC_OPTIONS env variable is empty" do
+    context "when TB_RSPEC_OPTIONS env variable is empty" do
       it "returns the default options" do
         expect(thread.rspec_options).to eq(" --format documentation --format json --out /tmp/rspec_report.json")
       end
     end
 
-    context "when RSPEC_OPTIONS env variable is present" do
-      before { ENV["RSPEC_OPTIONS"] = "--fail-fast=3" }
-      after  { ENV.delete("RSPEC_OPTIONS") }
+    context "when TB_RSPEC_OPTIONS env variable is present" do
+      before { ENV["TB_RSPEC_OPTIONS"] = "--fail-fast=3" }
+      after  { ENV.delete("TB_RSPEC_OPTIONS") }
 
       subject(:options) { thread.rspec_options }
 


### PR DESCRIPTION
If you want to pass additional parameters to RSpec, you can do that by setting
the `RSPEC_OPTIONS` environment variable.

For example, if you want to pass a `--fail-fast` option to RSpec, you can do it
like this:

``` bash
export RSPEC_OPTIONS = '--fail-fast'

rspec_booster --thread 2 # => runs: bundle exec rspec --fail-fast --format documentation --format json --out ~/rspec_report.json <file_list>
```