### PR TITLE
Pass thread count to booster classes

### DIFF
--- a/exe/cucumber_booster
+++ b/exe/cucumber_booster
@@ -3,7 +3,10 @@
 require "test_boosters"
 
 cli_options = TestBoosters::CliParser.parse
+
 thread_index = cli_options[:index] - 1
-cucumber_booster = TestBoosters::Cucumber::Booster.new(thread_index)
+thread_count = cli_options[:thread_count]
+
+cucumber_booster = TestBoosters::Cucumber::Booster.new(thread_index, thread_count)
 
 exit(cucumber_booster.run)

--- a/exe/cucumber_booster
+++ b/exe/cucumber_booster
@@ -4,7 +4,7 @@ require "test_boosters"
 
 cli_options = TestBoosters::CliParser.parse
 
-thread_index = cli_options[:index] - 1
+thread_index = cli_options[:thread_index] - 1
 thread_count = cli_options[:thread_count]
 
 cucumber_booster = TestBoosters::Cucumber::Booster.new(thread_index, thread_count)

--- a/exe/rspec_booster
+++ b/exe/rspec_booster
@@ -2,8 +2,11 @@
 
 require "test_boosters"
 
-cli_options   = TestBoosters::CliParser.parse
-thread_index  = cli_options[:index] - 1
-rspec_booster = TestBoosters::Rspec::Booster.new(thread_index)
+cli_options = TestBoosters::CliParser.parse
+
+thread_index = cli_options[:index] - 1
+thread_count = cli_options[:thread_count]
+
+rspec_booster = TestBoosters::Rspec::Booster.new(thread_index, thread_count)
 
 exit(rspec_booster.run)

--- a/exe/rspec_booster
+++ b/exe/rspec_booster
@@ -4,7 +4,7 @@ require "test_boosters"
 
 cli_options = TestBoosters::CliParser.parse
 
-thread_index = cli_options[:index] - 1
+thread_index = cli_options[:thread_index] - 1
 thread_count = cli_options[:thread_count]
 
 rspec_booster = TestBoosters::Rspec::Booster.new(thread_index, thread_count)

--- a/lib/test_boosters/cli_parser.rb
+++ b/lib/test_boosters/cli_parser.rb
@@ -6,7 +6,10 @@ module TestBoosters
       options = {}
 
       parser = OptionParser.new do |opts|
-        opts.on("--thread INDEX") { |index| options[:index] = index.to_i }
+        opts.on("--thread INDEX") do |parameter|
+          options[:thread_index] = parameter.split("/")[0].to_i
+          options[:thread_count] = parameter.split("/")[1].to_i
+        end
       end
 
       parser.parse!

--- a/lib/test_boosters/cli_parser.rb
+++ b/lib/test_boosters/cli_parser.rb
@@ -7,8 +7,10 @@ module TestBoosters
 
       parser = OptionParser.new do |opts|
         opts.on("--thread INDEX") do |parameter|
-          options[:thread_index] = parameter.split("/")[0].to_i
-          options[:thread_count] = parameter.split("/")[1].to_i
+          thread_index, thread_count, _rest = parameter.split("/")
+
+          options[:thread_index] = thread_index.to_i
+          options[:thread_count] = thread_count.to_i
         end
       end
 

--- a/lib/test_boosters/cucumber/booster.rb
+++ b/lib/test_boosters/cucumber/booster.rb
@@ -2,8 +2,12 @@ module TestBoosters
   module Cucumber
     class Booster
 
-      def initialize(thread_index)
+      attr_reader :thread_index
+      attr_reader :thread_count
+
+      def initialize(thread_index, thread_count)
         @thread_index = thread_index
+        @thread_count = thread_count
       end
 
       def run
@@ -18,12 +22,8 @@ module TestBoosters
         threads[@thread_index].run
       end
 
-      def thread_count
-        @thread_count ||= split_configuration.thread_count
-      end
-
       def threads
-        @threads ||= Array.new(thread_count) do |thread_index|
+        @threads ||= Array.new(@thread_count) do |thread_index|
           known_files = all_specs & split_configuration.files_for_thread(thread_index)
           leftover_files = TestBoosters::LeftoverFiles.select(all_leftover_specs, thread_count, thread_index)
 

--- a/lib/test_boosters/rspec/booster.rb
+++ b/lib/test_boosters/rspec/booster.rb
@@ -2,8 +2,12 @@ module TestBoosters
   module Rspec
     class Booster
 
-      def initialize(thread_index)
+      attr_reader :thread_index
+      attr_reader :thread_count
+
+      def initialize(thread_index, thread_count)
         @thread_index = thread_index
+        @thread_count = thread_count
       end
 
       def run
@@ -18,12 +22,8 @@ module TestBoosters
         threads[@thread_index].run
       end
 
-      def thread_count
-        @thread_count ||= split_configuration.thread_count
-      end
-
       def threads
-        @threads ||= Array.new(thread_count) do |thread_index|
+        @threads ||= Array.new(@thread_count) do |thread_index|
           known_files = all_specs & split_configuration.files_for_thread(thread_index)
           leftover_files = TestBoosters::LeftoverFiles.select(all_leftover_specs, thread_count, thread_index)
 

--- a/lib/test_boosters/split_configuration.rb
+++ b/lib/test_boosters/split_configuration.rb
@@ -32,10 +32,6 @@ module TestBoosters
       end
     end
 
-    def thread_count
-      @thread_count ||= threads.count
-    end
-
     private
 
     def load_data

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "1.5.0".freeze
+  VERSION = "1.6.0".freeze
 end

--- a/spec/integration/cucumber_booster/empty_split_configuration_spec.rb
+++ b/spec/integration/cucumber_booster/empty_split_configuration_spec.rb
@@ -46,7 +46,7 @@ describe "Cucumber Booster behaviour when split configuration is empty" do
   end
 
   specify "first thread's behaviour" do
-    output = `cucumber_booster --thread 1`
+    output = `cucumber_booster --thread 1/3`
 
     expect(output).to include("Feature: B")
     expect(output).to include("1 scenario (1 passed)")
@@ -56,7 +56,7 @@ describe "Cucumber Booster behaviour when split configuration is empty" do
   end
 
   specify "second thread's behaviour" do
-    output = `cucumber_booster --thread 2`
+    output = `cucumber_booster --thread 2/3`
 
     expect(output).to include("Feature: C")
     expect(output).to include("1 scenario (1 passed)")
@@ -66,7 +66,7 @@ describe "Cucumber Booster behaviour when split configuration is empty" do
   end
 
   specify "third thread's behaviour" do
-    output = `cucumber_booster --thread 3`
+    output = `cucumber_booster --thread 3/3`
 
     expect(output).to include("Feature: A")
     expect(output).to include("1 scenario (1 passed)")

--- a/spec/integration/cucumber_booster/failing_specs_spec.rb
+++ b/spec/integration/cucumber_booster/failing_specs_spec.rb
@@ -50,7 +50,7 @@ describe "Cucumber Booster behvaviour when the tests fail" do
   end
 
   specify "first thread's behaviour" do
-    output = `cucumber_booster --thread 1`
+    output = `cucumber_booster --thread 1/3`
 
     expect(output).to include("Feature: A")
     expect(output).to include("Feature: C")
@@ -61,7 +61,7 @@ describe "Cucumber Booster behvaviour when the tests fail" do
   end
 
   specify "second thread's behaviour" do
-    output = `cucumber_booster --thread 2`
+    output = `cucumber_booster --thread 2/3`
 
     expect(output).to include("Feature: B")
     expect(output).to include("1 scenario (1 failed)")
@@ -71,7 +71,7 @@ describe "Cucumber Booster behvaviour when the tests fail" do
   end
 
   specify "third thread's behaviour" do
-    output = `cucumber_booster --thread 3`
+    output = `cucumber_booster --thread 3/3`
 
     expect(output).to include("No files to run in this thread!")
     expect($?.exitstatus).to eq(0)

--- a/spec/integration/cucumber_booster/malformed_split_configuration_spec.rb
+++ b/spec/integration/cucumber_booster/malformed_split_configuration_spec.rb
@@ -46,7 +46,7 @@ describe "Cucumber Booster behvaviour when split configuration is malformed" do
   end
 
   specify "first thread's behaviour" do
-    output = `cucumber_booster --thread 1`
+    output = `cucumber_booster --thread 1/3`
 
     expect(output).to include("[ERROR] The split configuration file is malformed!")
     expect($?.exitstatus).to eq(1)
@@ -55,7 +55,7 @@ describe "Cucumber Booster behvaviour when split configuration is malformed" do
   end
 
   specify "second thread's behaviour" do
-    output = `cucumber_booster --thread 2`
+    output = `cucumber_booster --thread 2/3`
 
     expect(output).to include("[ERROR] The split configuration file is malformed!")
     expect($?.exitstatus).to eq(1)
@@ -64,7 +64,7 @@ describe "Cucumber Booster behvaviour when split configuration is malformed" do
   end
 
   specify "third thread's behaviour" do
-    output = `cucumber_booster --thread 3`
+    output = `cucumber_booster --thread 3/3`
 
     expect(output).to include("[ERROR] The split configuration file is malformed!")
     expect($?.exitstatus).to eq(1)

--- a/spec/integration/cucumber_booster/no_spec_files_spec.rb
+++ b/spec/integration/cucumber_booster/no_spec_files_spec.rb
@@ -36,7 +36,7 @@ describe "Cucumber Booster behvaviour there are no spec files" do
   end
 
   specify "first thread's behaviour" do
-    output = `cucumber_booster --thread 1`
+    output = `cucumber_booster --thread 1/3`
 
     expect($?.exitstatus).to eq(0)
     expect(output).to include("No files to run in this thread!")
@@ -45,7 +45,7 @@ describe "Cucumber Booster behvaviour there are no spec files" do
   end
 
   specify "second thread's behaviour" do
-    output = `cucumber_booster --thread 2`
+    output = `cucumber_booster --thread 2/3`
 
     expect($?.exitstatus).to eq(0)
     expect(output).to include("No files to run in this thread!")
@@ -54,7 +54,7 @@ describe "Cucumber Booster behvaviour there are no spec files" do
   end
 
   specify "third thread's behaviour" do
-    output = `cucumber_booster --thread 3`
+    output = `cucumber_booster --thread 3/3`
 
     expect($?.exitstatus).to eq(0)
     expect(output).to include("No files to run in this thread!")

--- a/spec/integration/cucumber_booster/passing_specs_spec.rb
+++ b/spec/integration/cucumber_booster/passing_specs_spec.rb
@@ -50,7 +50,7 @@ describe "Cucumber Booster behvaviour when the tests pass" do
   end
 
   specify "first thread's behaviour" do
-    output = `cucumber_booster --thread 1`
+    output = `cucumber_booster --thread 1/3`
 
     expect(output).to include("Feature: A")
     expect(output).to include("Feature: C")
@@ -61,7 +61,7 @@ describe "Cucumber Booster behvaviour when the tests pass" do
   end
 
   specify "second thread's behaviour" do
-    output = `cucumber_booster --thread 2`
+    output = `cucumber_booster --thread 2/3`
 
     expect(output).to include("Feature: B")
     expect(output).to include("1 scenario (1 passed)")
@@ -71,7 +71,7 @@ describe "Cucumber Booster behvaviour when the tests pass" do
   end
 
   specify "third thread's behaviour" do
-    output = `cucumber_booster --thread 3`
+    output = `cucumber_booster --thread 3/3`
 
     expect(output).to include("No files to run in this thread!")
     expect($?.exitstatus).to eq(0)

--- a/spec/integration/rspec_booster/empty_split_configuration_spec.rb
+++ b/spec/integration/rspec_booster/empty_split_configuration_spec.rb
@@ -44,7 +44,7 @@ describe "RSpec Booster behvaviour when split configuration is empty" do
   end
 
   specify "first thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 1`
+    output = `cd #{project_path} && rspec_booster --thread 1/3`
 
     expect(output).to include("1 example, 1 failure")
     expect($?.exitstatus).to eq(1)
@@ -53,7 +53,7 @@ describe "RSpec Booster behvaviour when split configuration is empty" do
   end
 
   specify "second thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 2`
+    output = `cd #{project_path} && rspec_booster --thread 2/3`
 
     expect(output).to include("1 example, 1 failure")
     expect($?.exitstatus).to eq(1)
@@ -62,7 +62,7 @@ describe "RSpec Booster behvaviour when split configuration is empty" do
   end
 
   specify "third thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 3`
+    output = `cd #{project_path} && rspec_booster --thread 3/3`
 
     expect(output).to include("1 example, 0 failure")
     expect($?.exitstatus).to eq(0)

--- a/spec/integration/rspec_booster/failing_specs_spec.rb
+++ b/spec/integration/rspec_booster/failing_specs_spec.rb
@@ -48,7 +48,7 @@ describe "RSpec Booster behvaviour when the tests fail" do
   end
 
   specify "first thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 1`
+    output = `cd #{project_path} && rspec_booster --thread 1/3`
 
     expect(output).to include("2 examples, 1 failure")
     expect($?.exitstatus).to eq(1)
@@ -57,7 +57,7 @@ describe "RSpec Booster behvaviour when the tests fail" do
   end
 
   specify "second thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 2`
+    output = `cd #{project_path} && rspec_booster --thread 2/3`
 
     expect(output).to include("1 example, 1 failure")
     expect($?.exitstatus).to eq(1)
@@ -66,7 +66,7 @@ describe "RSpec Booster behvaviour when the tests fail" do
   end
 
   specify "third thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 3`
+    output = `cd #{project_path} && rspec_booster --thread 3/3`
 
     expect(output).to include("No files to run in this thread!")
     expect($?.exitstatus).to eq(0)

--- a/spec/integration/rspec_booster/malformed_split_configuration_spec.rb
+++ b/spec/integration/rspec_booster/malformed_split_configuration_spec.rb
@@ -44,7 +44,7 @@ describe "RSpec Booster behvaviour when split configuration is malformed" do
   end
 
   specify "first thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 1`
+    output = `cd #{project_path} && rspec_booster --thread 1/3`
 
     expect(output).to include("[ERROR] The split configuration file is malformed!")
     expect($?.exitstatus).to eq(1)
@@ -53,7 +53,7 @@ describe "RSpec Booster behvaviour when split configuration is malformed" do
   end
 
   specify "second thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 2`
+    output = `cd #{project_path} && rspec_booster --thread 2/3`
 
     expect(output).to include("[ERROR] The split configuration file is malformed!")
     expect($?.exitstatus).to eq(1)
@@ -62,7 +62,7 @@ describe "RSpec Booster behvaviour when split configuration is malformed" do
   end
 
   specify "third thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 3`
+    output = `cd #{project_path} && rspec_booster --thread 3/3`
 
     expect(output).to include("[ERROR] The split configuration file is malformed!")
     expect($?.exitstatus).to eq(1)

--- a/spec/integration/rspec_booster/no_spec_files_spec.rb
+++ b/spec/integration/rspec_booster/no_spec_files_spec.rb
@@ -34,7 +34,7 @@ describe "RSpec Booster behvaviour there are no spec files" do
   end
 
   specify "first thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 1`
+    output = `cd #{project_path} && rspec_booster --thread 1/3`
 
     expect($?.exitstatus).to eq(0)
     expect(output).to include("No files to run in this thread!")
@@ -43,7 +43,7 @@ describe "RSpec Booster behvaviour there are no spec files" do
   end
 
   specify "second thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 2`
+    output = `cd #{project_path} && rspec_booster --thread 2/3`
 
     expect($?.exitstatus).to eq(0)
     expect(output).to include("No files to run in this thread!")
@@ -52,7 +52,7 @@ describe "RSpec Booster behvaviour there are no spec files" do
   end
 
   specify "third thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 3`
+    output = `cd #{project_path} && rspec_booster --thread 3/3`
 
     expect($?.exitstatus).to eq(0)
     expect(output).to include("No files to run in this thread!")

--- a/spec/integration/rspec_booster/passing_specs_spec.rb
+++ b/spec/integration/rspec_booster/passing_specs_spec.rb
@@ -48,7 +48,7 @@ describe "RSpec Booster behvaviour when the tests pass" do
   end
 
   specify "first thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 1`
+    output = `cd #{project_path} && rspec_booster --thread 1/3`
 
     expect(output).to include("2 examples, 0 failure")
     expect($?.exitstatus).to eq(0)
@@ -57,7 +57,7 @@ describe "RSpec Booster behvaviour when the tests pass" do
   end
 
   specify "second thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 2`
+    output = `cd #{project_path} && rspec_booster --thread 2/3`
 
     expect(output).to include("1 example, 0 failure")
     expect($?.exitstatus).to eq(0)
@@ -66,7 +66,7 @@ describe "RSpec Booster behvaviour when the tests pass" do
   end
 
   specify "third thread's behaviour" do
-    output = `cd #{project_path} && rspec_booster --thread 3`
+    output = `cd #{project_path} && rspec_booster --thread 3/3`
 
     expect(output).to include("No files to run in this thread!")
     expect($?.exitstatus).to eq(0)

--- a/spec/lib/test_boosters/cli_parser_spec.rb
+++ b/spec/lib/test_boosters/cli_parser_spec.rb
@@ -13,11 +13,11 @@ describe TestBoosters::CliParser do
 
     context "cli params contain the thread parameter" do
       it "recongnizes the --thread parameter" do
-        ARGV = ["--thread", "12"] # rubocop:disable Style/MutableConstant
+        ARGV = ["--thread", "12/32"] # rubocop:disable Style/MutableConstant
 
         params = TestBoosters::CliParser.parse
 
-        expect(params).to eq(:index => 12)
+        expect(params).to eq(:thread_index => 12, :thread_count => 32)
       end
     end
   end

--- a/spec/lib/test_boosters/cucumber/booster_spec.rb
+++ b/spec/lib/test_boosters/cucumber/booster_spec.rb
@@ -14,8 +14,9 @@ describe TestBoosters::Cucumber::Booster do
     ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] = split_configuration_path
   end
 
+  subject(:booster) { TestBoosters::Cucumber::Booster.new(0, 3) }
+
   describe "#specs_path" do
-    subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
 
     context "when the SPEC_PATH environment variable is set" do
       it "returns its values" do
@@ -33,8 +34,6 @@ describe TestBoosters::Cucumber::Booster do
   end
 
   describe "#split_configuration_path" do
-    subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
-
     context "when the CUCUMBER_SPLIT_CONFIGURATION_PATH environment variable is set" do
       it "returns its values" do
         expect(booster.split_configuration_path).to eq(split_configuration_path)
@@ -57,8 +56,6 @@ describe TestBoosters::Cucumber::Booster do
       Support::CucumberFilesFactory.create(:path => "#{specs_path}/b.feature")
     end
 
-    subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
-
     it "returns all the files" do
       expect(booster.all_specs).to eq [
         "#{specs_path}/a.feature",
@@ -79,8 +76,6 @@ describe TestBoosters::Cucumber::Booster do
         ])
     end
 
-    subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
-
     it "returns an instance of the split configuration" do
       expect(booster.split_configuration).to be_instance_of(TestBoosters::SplitConfiguration)
     end
@@ -96,8 +91,6 @@ describe TestBoosters::Cucumber::Booster do
           { :files => [] }
         ])
     end
-
-    subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
 
     it "returns thread count based on the number of threads in the split configuration" do
       expect(booster.thread_count).to eq(3)
@@ -120,8 +113,6 @@ describe TestBoosters::Cucumber::Booster do
           ])
       end
 
-      subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
-
       it "returns empty array" do
         expect(booster.all_leftover_specs).to eq([])
       end
@@ -137,8 +128,6 @@ describe TestBoosters::Cucumber::Booster do
           :path => split_configuration_path,
           :content => [])
       end
-
-      subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
 
       it "return the missing files" do
         expect(booster.all_leftover_specs).to eq([
@@ -161,8 +150,6 @@ describe TestBoosters::Cucumber::Booster do
             { :files => ["#{specs_path}/darth_vader/c.feature"] }
           ])
       end
-
-      subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
 
       it "returns empty array" do
         expect(booster.all_leftover_specs).to eq([])
@@ -189,8 +176,6 @@ describe TestBoosters::Cucumber::Booster do
           { :files => ["#{specs_path}/b.feature"] }
         ])
     end
-
-    subject(:booster) { TestBoosters::Cucumber::Booster.new(0) }
 
     it "returns 3 threads" do
       expect(booster.threads.count).to eq(3)
@@ -222,7 +207,7 @@ describe TestBoosters::Cucumber::Booster do
   describe "#run" do
     before do
       @threads = [double, double, double]
-      @booster = TestBoosters::Cucumber::Booster.new(1)
+      @booster = TestBoosters::Cucumber::Booster.new(1, 3)
 
       allow(@booster).to receive(:threads).and_return(@threads)
       allow(@threads[1]).to receive(:run)

--- a/spec/lib/test_boosters/cucumber/booster_spec.rb
+++ b/spec/lib/test_boosters/cucumber/booster_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 describe TestBoosters::Cucumber::Booster do
 
+  subject(:booster) { TestBoosters::Cucumber::Booster.new(0, 3) }
+
   let(:specs_path) { "/tmp/cucumber_features" }
   let(:split_configuration_path) { "/tmp/split_configuration.json" }
 
@@ -13,8 +15,6 @@ describe TestBoosters::Cucumber::Booster do
     ENV["SPEC_PATH"] = specs_path
     ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] = split_configuration_path
   end
-
-  subject(:booster) { TestBoosters::Cucumber::Booster.new(0, 3) }
 
   describe "#specs_path" do
 

--- a/spec/lib/test_boosters/rspec/booster_spec.rb
+++ b/spec/lib/test_boosters/rspec/booster_spec.rb
@@ -14,9 +14,9 @@ describe TestBoosters::Rspec::Booster do
     ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = split_configuration_path
   end
 
-  describe "#specs_path" do
-    subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
+  subject(:booster) { TestBoosters::Rspec::Booster.new(0, 3) }
 
+  describe "#specs_path" do
     context "when the SPEC_PATH environment variable is set" do
       it "returns its values" do
         expect(booster.specs_path).to eq(specs_path)
@@ -33,7 +33,6 @@ describe TestBoosters::Rspec::Booster do
   end
 
   describe "#split_configuration_path" do
-    subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
 
     context "when the RSPEC_SPLIT_CONFIGURATION_PATH environment variable is set" do
       it "returns its values" do
@@ -57,8 +56,6 @@ describe TestBoosters::Rspec::Booster do
       Support::RspecFilesFactory.create(:path => "#{specs_path}/b_spec.rb")
     end
 
-    subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
-
     it "returns all the files" do
       expect(booster.all_specs).to eq [
         "#{specs_path}/a_spec.rb",
@@ -79,28 +76,8 @@ describe TestBoosters::Rspec::Booster do
         ])
     end
 
-    subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
-
     it "returns an instance of the split configuration" do
       expect(booster.split_configuration).to be_instance_of(TestBoosters::SplitConfiguration)
-    end
-  end
-
-  describe "#thread_count" do
-    before do
-      Support::SplitConfigurationFactory.create(
-        :path => split_configuration_path,
-        :content => [
-          { :files => ["#{specs_path}/spec/a_spec.rb"] },
-          { :files => ["#{specs_path}/spec/b_spec"] },
-          { :files => [] }
-        ])
-    end
-
-    subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
-
-    it "returns thread count based on the number of threads in the split configuration" do
-      expect(booster.thread_count).to eq(3)
     end
   end
 
@@ -120,8 +97,6 @@ describe TestBoosters::Rspec::Booster do
           ])
       end
 
-      subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
-
       it "returns empty array" do
         expect(booster.all_leftover_specs).to eq([])
       end
@@ -137,8 +112,6 @@ describe TestBoosters::Rspec::Booster do
           :path => split_configuration_path,
           :content => [])
       end
-
-      subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
 
       it "return the missing files" do
         expect(booster.all_leftover_specs).to eq([
@@ -161,8 +134,6 @@ describe TestBoosters::Rspec::Booster do
             { :files => ["#{specs_path}/lib/darth_vader/c_spec.rb"] }
           ])
       end
-
-      subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
 
       it "returns empty array" do
         expect(booster.all_leftover_specs).to eq([])
@@ -189,8 +160,6 @@ describe TestBoosters::Rspec::Booster do
           { :files => ["#{specs_path}/b_spec.rb"] }
         ])
     end
-
-    subject(:booster) { TestBoosters::Rspec::Booster.new(0) }
 
     it "returns 3 threads" do
       expect(booster.threads.count).to eq(3)
@@ -222,7 +191,7 @@ describe TestBoosters::Rspec::Booster do
   describe "#run" do
     before do
       @threads = [double, double, double]
-      @booster = TestBoosters::Rspec::Booster.new(1)
+      @booster = TestBoosters::Rspec::Booster.new(1, 3)
 
       allow(@booster).to receive(:threads).and_return(@threads)
       allow(@threads[1]).to receive(:run)

--- a/spec/lib/test_boosters/rspec/booster_spec.rb
+++ b/spec/lib/test_boosters/rspec/booster_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 describe TestBoosters::Rspec::Booster do
 
+  subject(:booster) { TestBoosters::Rspec::Booster.new(0, 3) }
+
   let(:specs_path) { "/tmp/rspec_tests" }
   let(:split_configuration_path) { "/tmp/split_configuration.json" }
 
@@ -13,8 +15,6 @@ describe TestBoosters::Rspec::Booster do
     ENV["SPEC_PATH"] = specs_path
     ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = split_configuration_path
   end
-
-  subject(:booster) { TestBoosters::Rspec::Booster.new(0, 3) }
 
   describe "#specs_path" do
     context "when the SPEC_PATH environment variable is set" do


### PR DESCRIPTION
Makes life easier, and it can allow running the test boosters even when the
split configuration is not available in the system.