### PR TITLE
Display information when test booster starts

### DIFF
--- a/lib/test_boosters.rb
+++ b/lib/test_boosters.rb
@@ -12,6 +12,7 @@ module TestBoosters
   require "test_boosters/shell"
   require "test_boosters/leftover_files"
   require "test_boosters/insights_uploader"
+  require "test_boosters/project_info"
 
   require "test_boosters/rspec/booster"
   require "test_boosters/rspec/thread"

--- a/lib/test_boosters/cucumber/booster.rb
+++ b/lib/test_boosters/cucumber/booster.rb
@@ -11,7 +11,7 @@ module TestBoosters
       end
 
       def run
-        TestBoosters::Shell.display_title("Cucumber Booster v#{TestBoosters::VERSION}")
+        display_system_info
 
         unless split_configuration.valid?
           puts "[ERROR] The split configuration file is malformed!"
@@ -20,6 +20,16 @@ module TestBoosters
         end
 
         threads[@thread_index].run
+      end
+
+      def display_system_info
+        TestBoosters::Shell.display_title("Cucumber Booster v#{TestBoosters::VERSION}")
+
+        TestBoosters::ProjectInfo.display_ruby_version
+        TestBoosters::ProjectInfo.display_bundler_version
+        TestBoosters::ProjectInfo.display_cucumber_version
+
+        puts
       end
 
       def threads

--- a/lib/test_boosters/project_info.rb
+++ b/lib/test_boosters/project_info.rb
@@ -1,0 +1,30 @@
+module TestBoosters
+  module ProjectInfo
+    module_function
+
+    def display_ruby_version
+      version = `ruby --version`.gsub("ruby ", "")
+
+      puts "Ruby Version: #{version}"
+    end
+
+    def display_bundler_version
+      version = `bundle --version`.gsub("Bundler version ", "")
+
+      puts "Bundler Version: #{version}"
+    end
+
+    def display_rspec_version
+      version = `bundle exec rspec --version`
+
+      puts "RSpec Version: #{version}"
+    end
+
+    def display_cucumber_version
+      version = `bundle exec cucumber --version`
+
+      puts "Cucumber Version: #{version}"
+    end
+
+  end
+end

--- a/lib/test_boosters/rspec/booster.rb
+++ b/lib/test_boosters/rspec/booster.rb
@@ -13,6 +13,11 @@ module TestBoosters
       def run
         TestBoosters::Shell.display_title("RSpec Booster v#{TestBoosters::VERSION}")
 
+        TestBoosters::ProjectInfo.display_ruby_version
+        TestBoosters::ProjectInfo.display_bundler_version
+        TestBoosters::ProjectInfo.display_rspec_version
+        puts
+
         unless split_configuration.valid?
           puts "[ERROR] The split configuration file is malformed!"
 

--- a/lib/test_boosters/rspec/booster.rb
+++ b/lib/test_boosters/rspec/booster.rb
@@ -11,12 +11,7 @@ module TestBoosters
       end
 
       def run
-        TestBoosters::Shell.display_title("RSpec Booster v#{TestBoosters::VERSION}")
-
-        TestBoosters::ProjectInfo.display_ruby_version
-        TestBoosters::ProjectInfo.display_bundler_version
-        TestBoosters::ProjectInfo.display_rspec_version
-        puts
+        display_system_info
 
         unless split_configuration.valid?
           puts "[ERROR] The split configuration file is malformed!"
@@ -25,6 +20,16 @@ module TestBoosters
         end
 
         threads[@thread_index].run
+      end
+
+      def display_system_info
+        TestBoosters::Shell.display_title("RSpec Booster v#{TestBoosters::VERSION}")
+
+        TestBoosters::ProjectInfo.display_ruby_version
+        TestBoosters::ProjectInfo.display_bundler_version
+        TestBoosters::ProjectInfo.display_rspec_version
+
+        puts
       end
 
       def threads

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "1.6.1".freeze
+  VERSION = "1.6.2".freeze
 end

--- a/spec/lib/test_boosters/project_info_spec.rb
+++ b/spec/lib/test_boosters/project_info_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe TestBoosters::ProjectInfo do
+
+  describe ".display_ruby_version" do
+    it "displays ruby version" do
+      expect { described_class.display_ruby_version }.to output(/Ruby Version: 2/).to_stdout
+    end
+  end
+
+  describe ".display_bundler_version" do
+    it "displays bundler version" do
+      expect { described_class.display_bundler_version }.to output(/Bundler Version: 1/).to_stdout
+    end
+  end
+
+  describe ".display_rspec_version" do
+    it "displays rspec version" do
+      expect { described_class.display_rspec_version }.to output(/RSpec Version: 3/).to_stdout
+    end
+  end
+
+  describe ".display_cucumber_version" do
+    it "displays cucumber version" do
+      expect { described_class.display_cucumber_version }.to output(/Cucumber Version: 2/).to_stdout
+    end
+  end
+
+end


### PR DESCRIPTION
Added some information about the current system before running the test suite.

** nitpick: the header output is a bit crowded. We should improve it.
 
![screen shot 2017-03-24 at 2 08 12 pm](https://cloud.githubusercontent.com/assets/1779493/24295638/0bb22f8c-109c-11e7-9673-0c74f6fabe6f.png)
