### PR TITLE
Run without split configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,3 +90,15 @@ RSpec/SubjectStub:
 
 RSpec/DescribeClass:
   Enabled: false
+
+RSpec/LeadingSubject:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+RSpec/NotToNot:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/lib/test_boosters/cucumber/booster.rb
+++ b/lib/test_boosters/cucumber/booster.rb
@@ -11,24 +11,17 @@ module TestBoosters
       end
 
       def run
+        TestBoosters::Shell.display_title("Cucumber Booster v#{TestBoosters::VERSION}")
         display_system_info
-
-        unless split_configuration.valid?
-          puts "[ERROR] The split configuration file is malformed!"
-
-          return 1 # failure exit status
-        end
 
         threads[@thread_index].run
       end
 
       def display_system_info
-        TestBoosters::Shell.display_title("Cucumber Booster v#{TestBoosters::VERSION}")
-
         TestBoosters::ProjectInfo.display_ruby_version
         TestBoosters::ProjectInfo.display_bundler_version
         TestBoosters::ProjectInfo.display_cucumber_version
-
+        TestBoosters::ProjectInfo.display_split_configuration_info(split_configuration)
         puts
       end
 

--- a/lib/test_boosters/project_info.rb
+++ b/lib/test_boosters/project_info.rb
@@ -26,5 +26,11 @@ module TestBoosters
       puts "Cucumber Version: #{version}"
     end
 
+    def display_split_configuration_info(split_configuration)
+      puts "Split configuration present: #{split_configuration.present? ? "yes" : "no"}"
+      puts "Split configuration valid: #{split_configuration.valid? ? "yes" : "no"}"
+      puts "Split configuration file count: #{split_configuration.all_files.size}"
+    end
+
   end
 end

--- a/lib/test_boosters/rspec/booster.rb
+++ b/lib/test_boosters/rspec/booster.rb
@@ -11,25 +11,17 @@ module TestBoosters
       end
 
       def run
+        TestBoosters::Shell.display_title("RSpec Booster v#{TestBoosters::VERSION}")
         display_system_info
-
-        unless split_configuration.valid?
-          puts "[ERROR] The split configuration file is malformed!"
-
-          return 1 # failure exit status
-        end
 
         threads[@thread_index].run
       end
 
       def display_system_info
-        TestBoosters::Shell.display_title("RSpec Booster v#{TestBoosters::VERSION}")
-
         TestBoosters::ProjectInfo.display_ruby_version
         TestBoosters::ProjectInfo.display_bundler_version
         TestBoosters::ProjectInfo.display_rspec_version
         TestBoosters::ProjectInfo.display_split_configuration_info(split_configuration)
-
         puts
       end
 

--- a/lib/test_boosters/rspec/booster.rb
+++ b/lib/test_boosters/rspec/booster.rb
@@ -28,6 +28,7 @@ module TestBoosters
         TestBoosters::ProjectInfo.display_ruby_version
         TestBoosters::ProjectInfo.display_bundler_version
         TestBoosters::ProjectInfo.display_rspec_version
+        TestBoosters::ProjectInfo.display_split_configuration_info(split_configuration)
 
         puts
       end

--- a/lib/test_boosters/split_configuration.rb
+++ b/lib/test_boosters/split_configuration.rb
@@ -36,23 +36,28 @@ module TestBoosters
 
     # :reek:TooManyStatements
     def load_data
-      JSON.parse(File.read(@path)).map.with_index do |raw_thread, index|
-        TestBoosters::SplitConfiguration::Thread.new(raw_thread.fetch("files").sort, index)
-      end
-    rescue KeyError => ex
       @valid = false
 
-      TestBoosters::Logger.error("Split Configuration has invalid structure")
-      TestBoosters::Logger.error(ex.inspect)
+      content = JSON.parse(File.read(@path)).map.with_index do |raw_thread, index|
+        TestBoosters::SplitConfiguration::Thread.new(raw_thread.fetch("files").sort, index)
+      end
+
+      @valid = true
+
+      content
+    rescue KeyError => ex
+      log_error("Split Configuration has invalid structure", ex)
 
       []
     rescue JSON::ParserError => ex
-      @valid = false
-
-      TestBoosters::Logger.error("Split Configuration is not parsable")
-      TestBoosters::Logger.error(ex.inspect)
+      log_error("Split Configuration is not parsable", ex)
 
       []
+    end
+
+    def log_error(message, exception)
+      TestBoosters::Logger.error(message)
+      TestBoosters::Logger.error(exception.inspect)
     end
 
   end

--- a/lib/test_boosters/split_configuration.rb
+++ b/lib/test_boosters/split_configuration.rb
@@ -45,7 +45,7 @@ module TestBoosters
       @valid = true
 
       content
-    rescue KeyError => ex
+    rescue TypeError, KeyError => ex
       log_error("Split Configuration has invalid structure", ex)
 
       []

--- a/lib/test_boosters/split_configuration.rb
+++ b/lib/test_boosters/split_configuration.rb
@@ -39,9 +39,17 @@ module TestBoosters
       JSON.parse(File.read(@path)).map.with_index do |raw_thread, index|
         TestBoosters::SplitConfiguration::Thread.new(raw_thread.fetch("files").sort, index)
       end
-    rescue StandardError => ex
+    rescue KeyError => ex
       @valid = false
 
+      TestBoosters::Logger.error("Split Configuration has invalid structure")
+      TestBoosters::Logger.error(ex.inspect)
+
+      []
+    rescue JSON::ParserError => ex
+      @valid = false
+
+      TestBoosters::Logger.error("Split Configuration is not parsable")
       TestBoosters::Logger.error(ex.inspect)
 
       []

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "1.6.2".freeze
+  VERSION = "1.7.0".freeze
 end

--- a/spec/integration/cucumber_booster/malformed_split_configuration_spec.rb
+++ b/spec/integration/cucumber_booster/malformed_split_configuration_spec.rb
@@ -48,28 +48,31 @@ describe "Cucumber Booster behvaviour when split configuration is malformed" do
   specify "first thread's behaviour" do
     output = `cucumber_booster --thread 1/3`
 
-    expect(output).to include("[ERROR] The split configuration file is malformed!")
-    expect($?.exitstatus).to eq(1)
+    expect(output).to include("Feature: B")
+    expect(output).to include("1 scenario (1 passed)")
+    expect($?.exitstatus).to eq(0)
 
-    expect(File.exist?(cucumber_report_path)).to eq(false)
+    expect(File.exist?(cucumber_report_path)).to eq(true)
   end
 
   specify "second thread's behaviour" do
     output = `cucumber_booster --thread 2/3`
 
-    expect(output).to include("[ERROR] The split configuration file is malformed!")
-    expect($?.exitstatus).to eq(1)
+    expect(output).to include("Feature: C")
+    expect(output).to include("1 scenario (1 passed)")
+    expect($?.exitstatus).to eq(0)
 
-    expect(File.exist?(cucumber_report_path)).to eq(false)
+    expect(File.exist?(cucumber_report_path)).to eq(true)
   end
 
   specify "third thread's behaviour" do
     output = `cucumber_booster --thread 3/3`
 
-    expect(output).to include("[ERROR] The split configuration file is malformed!")
-    expect($?.exitstatus).to eq(1)
+    expect(output).to include("Feature: A")
+    expect(output).to include("1 scenario (1 passed)")
+    expect($?.exitstatus).to eq(0)
 
-    expect(File.exist?(cucumber_report_path)).to eq(false)
+    expect(File.exist?(cucumber_report_path)).to eq(true)
   end
 
 end

--- a/spec/integration/cucumber_booster/no_split_configuration_spec.rb
+++ b/spec/integration/cucumber_booster/no_split_configuration_spec.rb
@@ -2,8 +2,74 @@ require "spec_helper"
 
 describe "Cucumber Booster behvaviour when there is no split configuration" do
 
-  it "runs specs based on leftover files colculation" do
-    # TODO
+  let(:specs_path) { "features" }
+  let(:split_configuration_path) { "/tmp/cucumber_split_configuration.json" }
+  let(:cucumber_report_path) { "/tmp/cucumber_report.json" }
+
+  before do
+    # Set up environment variables
+    ENV["SPEC_PATH"] = specs_path
+    ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] = split_configuration_path
+    ENV["REPORT_PATH"] = cucumber_report_path
+
+    # set up features directory
+    FileUtils.rm_f(cucumber_report_path)
+    FileUtils.rm_rf("features")
+    FileUtils.mkdir_p("features")
+    FileUtils.rm_rf("config")
+    FileUtils.mkdir_p("config")
+    FileUtils.rm_f(split_configuration_path)
+    File.write("config/cucumber.yml", "default: --format pretty\n")
+
+    # Create spec files
+    Support::CucumberFilesFactory.create(:name => "A", :path => "#{specs_path}/a.feature")
+    Support::CucumberFilesFactory.create(:name => "B", :path => "#{specs_path}/b.feature")
+    Support::CucumberFilesFactory.create(:name => "C", :path => "#{specs_path}/admin/c.feature")
+
+    # make sure that everything is set up as it should be
+    expect(File.exist?(cucumber_report_path)).to eq(false)
+    expect(File.exist?(split_configuration_path)).to eq(false)
+
+    expect(Dir["#{specs_path}/**/*"].sort).to eq([
+      "#{specs_path}/a.feature",
+      "#{specs_path}/admin",
+      "#{specs_path}/admin/c.feature",
+      "#{specs_path}/b.feature",
+      "#{specs_path}/step_definitions",
+      "#{specs_path}/step_definitions/a_step.rb",
+      "#{specs_path}/step_definitions/b_step.rb",
+      "#{specs_path}/step_definitions/c_step.rb"
+    ])
+  end
+
+  specify "first thread's behaviour" do
+    output = `cucumber_booster --thread 1/3`
+
+    expect(output).to include("Feature: B")
+    expect(output).to include("1 scenario (1 passed)")
+    expect($?.exitstatus).to eq(0)
+
+    expect(File.exist?(cucumber_report_path)).to eq(true)
+  end
+
+  specify "second thread's behaviour" do
+    output = `cucumber_booster --thread 2/3`
+
+    expect(output).to include("Feature: C")
+    expect(output).to include("1 scenario (1 passed)")
+    expect($?.exitstatus).to eq(0)
+
+    expect(File.exist?(cucumber_report_path)).to eq(true)
+  end
+
+  specify "third thread's behaviour" do
+    output = `cucumber_booster --thread 3/3`
+
+    expect(output).to include("Feature: A")
+    expect(output).to include("1 scenario (1 passed)")
+    expect($?.exitstatus).to eq(0)
+
+    expect(File.exist?(cucumber_report_path)).to eq(true)
   end
 
 end

--- a/spec/integration/rspec_booster/malformed_split_configuration_spec.rb
+++ b/spec/integration/rspec_booster/malformed_split_configuration_spec.rb
@@ -46,28 +46,28 @@ describe "RSpec Booster behvaviour when split configuration is malformed" do
   specify "first thread's behaviour" do
     output = `cd #{project_path} && rspec_booster --thread 1/3`
 
-    expect(output).to include("[ERROR] The split configuration file is malformed!")
-    expect($?.exitstatus).to eq(1)
+    expect(output).to include("1 example, 0 failure")
+    expect($?.exitstatus).to eq(0)
 
-    expect(File.exist?(rspec_report_path)).to eq(false)
+    expect(File.exist?(rspec_report_path)).to eq(true)
   end
 
   specify "second thread's behaviour" do
     output = `cd #{project_path} && rspec_booster --thread 2/3`
 
-    expect(output).to include("[ERROR] The split configuration file is malformed!")
-    expect($?.exitstatus).to eq(1)
+    expect(output).to include("1 example, 0 failure")
+    expect($?.exitstatus).to eq(0)
 
-    expect(File.exist?(rspec_report_path)).to eq(false)
+    expect(File.exist?(rspec_report_path)).to eq(true)
   end
 
   specify "third thread's behaviour" do
     output = `cd #{project_path} && rspec_booster --thread 3/3`
 
-    expect(output).to include("[ERROR] The split configuration file is malformed!")
-    expect($?.exitstatus).to eq(1)
+    expect(output).to include("1 example, 0 failure")
+    expect($?.exitstatus).to eq(0)
 
-    expect(File.exist?(rspec_report_path)).to eq(false)
+    expect(File.exist?(rspec_report_path)).to eq(true)
   end
 
 end

--- a/spec/integration/rspec_booster/no_split_configuration_spec.rb
+++ b/spec/integration/rspec_booster/no_split_configuration_spec.rb
@@ -2,8 +2,68 @@ require "spec_helper"
 
 describe "RSpec Booster behvaviour when there is no split configuration" do
 
-  it "runs specs based on leftover files colculation" do
-    # TODO
+  let(:project_path) { "/tmp/project_path-#{SecureRandom.uuid}" }
+  let(:specs_path) { "#{project_path}/spec" }
+  let(:split_configuration_path) { "/tmp/rspec_split_configuration.json" }
+  let(:rspec_report_path) { "/tmp/rspec_report.json" }
+
+  before do
+    # Set up environment variables
+    ENV["SPEC_PATH"] = specs_path
+    ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = split_configuration_path
+    ENV["REPORT_PATH"] = rspec_report_path
+
+    # Set up test dir structure
+    FileUtils.rm_rf(specs_path)
+    FileUtils.mkdir_p(specs_path)
+    FileUtils.rm_f(rspec_report_path)
+
+    # Create spec files
+    Support::RspecFilesFactory.create(:path => "#{specs_path}/a_spec.rb", :result => :failing)
+    Support::RspecFilesFactory.create(:path => "#{specs_path}/b_spec.rb", :result => :failing)
+    Support::RspecFilesFactory.create(:path => "#{specs_path}/lib/c_spec.rb", :result => :passing)
+
+    # Construct spec helper file
+    File.write("#{specs_path}/spec_helper.rb", "")
+
+    # make sure that everything is set up as it should be
+    expect(File.exist?(rspec_report_path)).to eq(false)
+    expect(File.exist?(split_configuration_path)).to eq(false)
+
+    expect(Dir["#{specs_path}/**/*"].sort).to eq([
+      "#{specs_path}/a_spec.rb",
+      "#{specs_path}/b_spec.rb",
+      "#{specs_path}/lib",
+      "#{specs_path}/lib/c_spec.rb",
+      "#{specs_path}/spec_helper.rb"
+    ])
+  end
+
+  specify "first thread's behaviour" do
+    output = `cd #{project_path} && rspec_booster --thread 1/3`
+
+    expect(output).to include("1 example, 1 failure")
+    expect($?.exitstatus).to eq(1)
+
+    expect(File.exist?(rspec_report_path)).to eq(true)
+  end
+
+  specify "second thread's behaviour" do
+    output = `cd #{project_path} && rspec_booster --thread 2/3`
+
+    expect(output).to include("1 example, 1 failure")
+    expect($?.exitstatus).to eq(1)
+
+    expect(File.exist?(rspec_report_path)).to eq(true)
+  end
+
+  specify "third thread's behaviour" do
+    output = `cd #{project_path} && rspec_booster --thread 3/3`
+
+    expect(output).to include("1 example, 0 failure")
+    expect($?.exitstatus).to eq(0)
+
+    expect(File.exist?(rspec_report_path)).to eq(true)
   end
 
 end

--- a/spec/integration/rspec_booster/no_split_configuration_spec.rb
+++ b/spec/integration/rspec_booster/no_split_configuration_spec.rb
@@ -17,6 +17,7 @@ describe "RSpec Booster behvaviour when there is no split configuration" do
     FileUtils.rm_rf(specs_path)
     FileUtils.mkdir_p(specs_path)
     FileUtils.rm_f(rspec_report_path)
+    FileUtils.rm_f(split_configuration_path)
 
     # Create spec files
     Support::RspecFilesFactory.create(:path => "#{specs_path}/a_spec.rb", :result => :failing)

--- a/spec/lib/test_boosters/cucumber/booster_spec.rb
+++ b/spec/lib/test_boosters/cucumber/booster_spec.rb
@@ -222,26 +222,5 @@ describe TestBoosters::Cucumber::Booster do
 
       @booster.run
     end
-
-    context "split configuration is malformed" do
-      before do
-        allow(@booster.split_configuration).to receive(:valid?).and_return(false)
-      end
-
-      it "displays title" do
-        expect { @booster.run }.to output(/Cucumber Booster v#{TestBoosters::VERSION}/).to_stdout
-      end
-
-      it "displays that the file is malformed" do
-        expect { @booster.run }.to output(/\[ERROR\] The split configuration file is malformed!/).to_stdout
-      end
-
-      it "return exit status 1" do
-        allow($stdout).to receive(:puts)
-
-        expect(@booster.run).to eq(1)
-      end
-    end
   end
-
 end

--- a/spec/lib/test_boosters/project_info_spec.rb
+++ b/spec/lib/test_boosters/project_info_spec.rb
@@ -27,20 +27,22 @@ describe TestBoosters::ProjectInfo do
   end
 
   describe ".display_split_configuration_info" do
-    let(:files) { ["file1", "file2", "file3" ] }
-    let(:split_conf) { double(TestBoosters::SplitConfiguration, :all_files => files, :present? => true, :valid? => false) }
+    let(:files) { ["file1", "file2", "file3"] }
 
-    it "displays its presence" do
-      expect { described_class.display_split_configuration_info(split_conf) }.to output(/Split configuration present: yes/).to_stdout
+    let(:split_conf) do
+      instance_double(TestBoosters::SplitConfiguration,
+                      :all_files => files,
+                      :present? => true,
+                      :valid? => false)
     end
 
-    it "displays its validity" do
-      expect { described_class.display_split_configuration_info(split_conf) }.to output(/Split configuration valid: no/).to_stdout
+    subject do
+      -> { described_class.display_split_configuration_info(split_conf) }
     end
 
-    it "displays its file count" do
-      expect { described_class.display_split_configuration_info(split_conf) }.to output(/Split configuration file count: 3/).to_stdout
-    end
+    it { is_expected.to output(/Split configuration present: yes/).to_stdout }
+    it { is_expected.to output(/Split configuration valid: no/).to_stdout }
+    it { is_expected.to output(/Split configuration file count: 3/).to_stdout }
   end
 
 end

--- a/spec/lib/test_boosters/project_info_spec.rb
+++ b/spec/lib/test_boosters/project_info_spec.rb
@@ -26,4 +26,21 @@ describe TestBoosters::ProjectInfo do
     end
   end
 
+  describe ".display_split_configuration_info" do
+    let(:files) { ["file1", "file2", "file3" ] }
+    let(:split_conf) { double(TestBoosters::SplitConfiguration, :all_files => files, :present? => true, :valid? => false) }
+
+    it "displays its presence" do
+      expect { described_class.display_split_configuration_info(split_conf) }.to output(/Split configuration present: yes/).to_stdout
+    end
+
+    it "displays its validity" do
+      expect { described_class.display_split_configuration_info(split_conf) }.to output(/Split configuration valid: no/).to_stdout
+    end
+
+    it "displays its file count" do
+      expect { described_class.display_split_configuration_info(split_conf) }.to output(/Split configuration file count: 3/).to_stdout
+    end
+  end
+
 end

--- a/spec/lib/test_boosters/rspec/booster_spec.rb
+++ b/spec/lib/test_boosters/rspec/booster_spec.rb
@@ -206,26 +206,5 @@ describe TestBoosters::Rspec::Booster do
 
       @booster.run
     end
-
-    context "split configuration is malformed" do
-      before do
-        allow(@booster.split_configuration).to receive(:valid?).and_return(false)
-      end
-
-      it "displays title" do
-        expect { @booster.run }.to output(/RSpec Booster v#{TestBoosters::VERSION}/).to_stdout
-      end
-
-      it "displays that the file is malformed" do
-        expect { @booster.run }.to output(/\[ERROR\] The split configuration file is malformed!/).to_stdout
-      end
-
-      it "return exit status 1" do
-        allow($stdout).to receive(:puts)
-
-        expect(@booster.run).to eq(1)
-      end
-    end
   end
-
 end

--- a/spec/lib/test_boosters/split_configuration_spec.rb
+++ b/spec/lib/test_boosters/split_configuration_spec.rb
@@ -6,6 +6,7 @@ describe TestBoosters::SplitConfiguration do
     subject(:configuration) { TestBoosters::SplitConfiguration.new("/tmp/non_existing_file_path") }
 
     it { is_expected.not_to be_present }
+    it { is_expected.to be_valid }
 
     describe "#all_files" do
       it "is an empty array" do
@@ -13,9 +14,40 @@ describe TestBoosters::SplitConfiguration do
       end
     end
 
-    describe "#threads" do
+    describe "#files_for_thread" do
       it "is an empty array" do
-        expect(configuration.threads).to eq([])
+        expect(configuration.files_for_thread(10)).to eq([])
+      end
+    end
+  end
+
+  context "file is broken" do
+    before do
+      content = [
+        { :files => ["a_spec.rb", "d_spec.rb", "c_spec.rb"] },
+        { :files => ["f_spec.rb", "b_spec.rb"] },
+        { :files => [] }
+      ]
+
+      @path = "/tmp/split_configuration"
+
+      File.write(@path, "try to parse me :)")
+    end
+
+    subject(:configuration) { TestBoosters::SplitConfiguration.new(@path) }
+
+    it { is_expected.to be_present }
+    it { is_expected.to_not be_valid }
+
+    describe "#all_files" do
+      it "is an empty array" do
+        expect(configuration.all_files).to eq([])
+      end
+    end
+
+    describe "#files_for_thread" do
+      it "is an empty array" do
+        expect(configuration.files_for_thread(10)).to eq([])
       end
     end
   end

--- a/spec/lib/test_boosters/split_configuration_spec.rb
+++ b/spec/lib/test_boosters/split_configuration_spec.rb
@@ -21,7 +21,7 @@ describe TestBoosters::SplitConfiguration do
     end
   end
 
-  context "file is broken" do
+  context "file is not parsable" do
     before do
       content = [
         { :files => ["a_spec.rb", "d_spec.rb", "c_spec.rb"] },
@@ -32,6 +32,33 @@ describe TestBoosters::SplitConfiguration do
       @path = "/tmp/split_configuration"
 
       File.write(@path, "try to parse me :)")
+    end
+
+    subject(:configuration) { TestBoosters::SplitConfiguration.new(@path) }
+
+    it { is_expected.to be_present }
+    it { is_expected.to_not be_valid }
+
+    describe "#all_files" do
+      it "is an empty array" do
+        expect(configuration.all_files).to eq([])
+      end
+    end
+
+    describe "#files_for_thread" do
+      it "is an empty array" do
+        expect(configuration.files_for_thread(10)).to eq([])
+      end
+    end
+  end
+
+  context "file is parsable, but contains invalid structure" do
+    before do
+      content = [{ :parse => :me }]
+
+      @path = "/tmp/split_configuration"
+
+      File.write(@path, content.to_json)
     end
 
     subject(:configuration) { TestBoosters::SplitConfiguration.new(@path) }

--- a/spec/lib/test_boosters/split_configuration_spec.rb
+++ b/spec/lib/test_boosters/split_configuration_spec.rb
@@ -23,12 +23,6 @@ describe TestBoosters::SplitConfiguration do
 
   context "file is not parsable" do
     before do
-      content = [
-        { :files => ["a_spec.rb", "d_spec.rb", "c_spec.rb"] },
-        { :files => ["f_spec.rb", "b_spec.rb"] },
-        { :files => [] }
-      ]
-
       @path = "/tmp/split_configuration"
 
       File.write(@path, "try to parse me :)")
@@ -37,7 +31,7 @@ describe TestBoosters::SplitConfiguration do
     subject(:configuration) { TestBoosters::SplitConfiguration.new(@path) }
 
     it { is_expected.to be_present }
-    it { is_expected.to_not be_valid }
+    it { is_expected.not_to be_valid }
 
     describe "#all_files" do
       it "is an empty array" do


### PR DESCRIPTION
This PR handles three cases:

- when the split configuraton file is missing
- when the split configuration file is present but not parsable
- when the split configuration file is present, parsable, but contains an invalid structure