### PR TITLE
Test Boosters for RSpec version < 3.3

### DIFF
--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "2.2.1".freeze
+  VERSION = "2.2.2".freeze
 end

--- a/rspec_formatters/semaphore_rspec3_json_formatter.rb
+++ b/rspec_formatters/semaphore_rspec3_json_formatter.rb
@@ -35,16 +35,21 @@ class SemaphoreFormatter < RSpec::Core::Formatters::BaseFormatter
   end
 
   def file_path(example)
-    # In case of a shared_example
-    # example[:file_path] returns the path of the shared_example file
+    # For shared examples 'example.file_path' returns the path of the shared example file.
+    # This is not optinal for our use case because we can't estimate the duration of the
+    # original spec file.
     #
-    # We are interested in the duration of the file from which the shared_example was called instead.
-    #
-    # We can get this infor from `example.id`.
-    #
-    # It has the following format: `./spec/models/analysis_spec.rb[1:17:1:1:1]`
-    # We are droping the angle brackets at the end.
+    # To resolve this, we use `example.metadata[:example_group]` that contains the correct
+    # file path for both shared examples and regular tests
 
-    example.id.gsub(/\[.*\]$/, "")
+    find_example_group_root_path(example.metadata[:example_group])
+  end
+
+  def find_example_group_root_path(example_group)
+    if example_group.has_key?(:parent_example_group)
+      find_example_group_root_path(example_group[:parent_example_group])
+    else
+      example_group[:file_path]
+    end
   end
 end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -3,6 +3,8 @@ module IntegrationHelper
 
     REPO = "https://github.com/renderedtext/test-boosters-tests.git".freeze
 
+    attr_reader :project_path
+
     def initialize(test_project)
       @repo_path = "/tmp/test-boosters-tests"
       @project_path = "/tmp/test-boosters-tests/#{test_project}"

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -17,10 +17,11 @@ describe "RSpec Booster", :integration do
       @test_repo.clone
       @test_repo.set_env_var("RSPEC_SPLIT_CONFIGURATION_PATH", @split_configuration_path)
 
-      # set RSpec version of the test project
+      # set RSpec version in the test project
       rspec_dependancy_pattern = 'spec.add_development_dependency "rspec".*$'
       rspec_dependancy_version = "spec.add_development_dependency \"rspec\", '#{@rspec_version}'"
-      system(%Q{sed -i 's/#{rspec_dependancy_pattern}/#{rspec_dependancy_version}/' #{@test_repo.project_path}/rspec_project.gemspec})
+      gemspec_path = "#{@test_repo.project_path}/rspec_project.gemspec"
+      system(%{sed -i 's/#{rspec_dependancy_pattern}/#{rspec_dependancy_version}/' #{gemspec_path}})
 
       File.write(@split_configuration_path, [
         { :files => [] },

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -3,61 +3,82 @@ require_relative "./integration_helper"
 
 describe "RSpec Booster", :integration do
 
-  before(:all) do
-    @split_configuration_path = "/tmp/rspec_split_configuration.json"
+  shared_examples "an rspec booster" do |options|
+    before(:all) do
+      @rspec_version = options.fetch(:rspec_version)
 
-    @test_repo = IntegrationHelper::TestRepo.new("rspec_project")
-    @test_repo.clone
-    @test_repo.set_env_var("RSPEC_SPLIT_CONFIGURATION_PATH", @split_configuration_path)
+      puts "======================================================================"
+      puts "Testing RSpec Booster with RSpec version #{@rspec_version}            "
+      puts "======================================================================"
 
-    File.write(@split_configuration_path, [
-      { :files => [] },
-      { :files => ["spec/lib/a_spec.rb"] }
-    ].to_json)
+      @split_configuration_path = "/tmp/rspec_split_configuration.json"
 
-    @test_repo.run_command("bundle install --path vendor/bundle")
+      @test_repo = IntegrationHelper::TestRepo.new("rspec_project")
+      @test_repo.clone
+      @test_repo.set_env_var("RSPEC_SPLIT_CONFIGURATION_PATH", @split_configuration_path)
+
+      # set RSpec version of the test project
+      rspec_dependancy_pattern = 'spec.add_development_dependency "rspec".*$'
+      rspec_dependancy_version = "spec.add_development_dependency \"rspec\", '#{@rspec_version}'"
+      system(%Q{sed -i 's/#{rspec_dependancy_pattern}/#{rspec_dependancy_version}/' #{@test_repo.project_path}/rspec_project.gemspec})
+
+      File.write(@split_configuration_path, [
+        { :files => [] },
+        { :files => ["spec/lib/a_spec.rb"] }
+      ].to_json)
+
+      @test_repo.run_command("bundle install --path vendor/bundle")
+    end
+
+    before { FileUtils.rm_f("#{ENV["HOME"]}/rspec_report.json") }
+
+    specify "first job's behaviour" do
+      output = @test_repo.run_booster("rspec_booster --job 1/3")
+
+      expect(output).to include("3 examples, 1 failure")
+      expect($?.exitstatus).to eq(1)
+
+      expect(File).to exist("#{ENV["HOME"]}/rspec_report.json")
+    end
+
+    specify "second job's behaviour" do
+      output = @test_repo.run_booster("rspec_booster --job 2/3")
+
+      expect(output).to include("1 example, 0 failures")
+      expect($?.exitstatus).to eq(0)
+
+      expect(File).to exist("#{ENV["HOME"]}/rspec_report.json")
+    end
+
+    specify "third job's behaviour" do
+      output = @test_repo.run_booster("rspec_booster --job 3/3")
+
+      expect(output).to include("No files to run in this job!")
+      expect($?.exitstatus).to eq(0)
+
+      expect(File).to_not exist("#{ENV["HOME"]}/rspec_report.json")
+    end
+
+    specify "rspec_report format" do
+      @test_repo.run_booster("rspec_booster --job 1/3")
+
+      report = JSON.parse(File.read("#{ENV["HOME"]}/rspec_report.json"))
+      expected = JSON.parse(File.read("spec/expected_rspec_report_format.json"))
+
+      # ignore actual runtimes
+      report["examples"].each { |e| e["run_time"] = 0 }
+      expected["examples"].each { |e| e["run_time"] = 0 }
+
+      expect(report).to eq(expected)
+    end
   end
 
-  before { FileUtils.rm_f("#{ENV["HOME"]}/rspec_report.json") }
-
-  specify "first job's behaviour" do
-    output = @test_repo.run_booster("rspec_booster --job 1/3")
-
-    expect(output).to include("3 examples, 1 failure")
-    expect($?.exitstatus).to eq(1)
-
-    expect(File).to exist("#{ENV["HOME"]}/rspec_report.json")
-  end
-
-  specify "second job's behaviour" do
-    output = @test_repo.run_booster("rspec_booster --job 2/3")
-
-    expect(output).to include("1 example, 0 failures")
-    expect($?.exitstatus).to eq(0)
-
-    expect(File).to exist("#{ENV["HOME"]}/rspec_report.json")
-  end
-
-  specify "third job's behaviour" do
-    output = @test_repo.run_booster("rspec_booster --job 3/3")
-
-    expect(output).to include("No files to run in this job!")
-    expect($?.exitstatus).to eq(0)
-
-    expect(File).to_not exist("#{ENV["HOME"]}/rspec_report.json")
-  end
-
-  specify "rspec_report format" do
-    @test_repo.run_booster("rspec_booster --job 1/3")
-
-    report = JSON.parse(File.read("#{ENV["HOME"]}/rspec_report.json"))
-    expected = JSON.parse(File.read("spec/expected_rspec_report_format.json"))
-
-    # ignore actual runtimes
-    report["examples"].each { |e| e["run_time"] = 0 }
-    expected["examples"].each { |e| e["run_time"] = 0 }
-
-    expect(report).to eq(expected)
-  end
+  it_behaves_like "an rspec booster", :rspec_version => 3.6
+  it_behaves_like "an rspec booster", :rspec_version => 3.5
+  it_behaves_like "an rspec booster", :rspec_version => 3.4
+  it_behaves_like "an rspec booster", :rspec_version => 3.3
+  it_behaves_like "an rspec booster", :rspec_version => 3.2
+  it_behaves_like "an rspec booster", :rspec_version => 3.1
+  it_behaves_like "an rspec booster", :rspec_version => 3.0
 
 end


### PR DESCRIPTION
Two important changes in this pull request:

- automatic tests for all major RSpec versions 3.6, 3.5, 3.4, 3.3, 3.2, 3.1, 3.0.
- fix for RSpec version 3.2, 3.1, 3.0