### PR TITLE
Create helper method to set which cucumber yaml to use

### DIFF
--- a/spec/integration/cucumber_spec.rb
+++ b/spec/integration/cucumber_spec.rb
@@ -9,6 +9,7 @@ describe "Cucumber Booster", :integration do
     @test_repo = IntegrationHelper::TestRepo.new("cucumber_project")
     @test_repo.clone
     @test_repo.set_env_var("CUCUMBER_SPLIT_CONFIGURATION_PATH", @split_configuration_path)
+    @test_repo.use_cucumber_config("cucumber.yml.empty")
 
     File.write(@split_configuration_path, [
       { :files => [] },

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -21,7 +21,11 @@ module IntegrationHelper
     end
 
     def use_cucumber_config(file)
-      system("mv config/#{file} config/cucumber.yml")
+      if File.file?("#{@project_path}/config/#{file}")
+        system("mv #{@project_path}/config/#{file} #{@project_path}/config/cucumber.yml")
+      else
+        raise "#{file} doesn't exist. Please use existing configuration yaml."
+      end
     end
 
     # :reek:TooManyStatements

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -20,6 +20,10 @@ module IntegrationHelper
       @env += "#{name}=#{value} "
     end
 
+    def use_cucumber_config(file)
+      system("mv config/#{file} config/cucumber.yml")
+    end
+
     # :reek:TooManyStatements
     def run_command(command)
       Bundler.with_clean_env do

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -21,11 +21,10 @@ module IntegrationHelper
     end
 
     def use_cucumber_config(file)
-      if File.file?("#{@project_path}/config/#{file}")
-        system("mv #{@project_path}/config/#{file} #{@project_path}/config/cucumber.yml")
-      else
-        raise "#{file} doesn't exist. Please use existing configuration yaml."
-      end
+      file_exists = File.file?("#{@project_path}/config/#{file}")
+      raise "#{file} doesn't exist. Please use existing configuration yaml." unless file_exists
+
+      system("mv #{@project_path}/config/#{file} #{@project_path}/config/cucumber.yml")
     end
 
     # :reek:TooManyStatements


### PR DESCRIPTION
I want to test with different cucumber.yml files to support multiple use cases.

We only test with empty yaml file. I want to test what is happening when user already defined cucumber format in default cucumber profile.

Have a look at this at test-boosters-tests repo:
https://github.com/renderedtext/test-boosters-tests/pull/1
Tests will pass once ^ is merged.

What do you think?