### PR TITLE
Upgrade rubocop version

### DIFF
--- a/test_boosters.gemspec
+++ b/test_boosters.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "activesupport", "~> 4.0"
 
-  spec.add_development_dependency "rubocop", "~> 0.47.1"
+  spec.add_development_dependency "rubocop", "~> 0.49.0"
   spec.add_development_dependency "rubocop-rspec", "~> 1.13.0"
   spec.add_development_dependency "reek", "4.5.6"
   spec.add_development_dependency "simplecov", "~> 0.13"


### PR DESCRIPTION
Fix potential security vulnerability in `rubocop` dependency

![security_warning](https://user-images.githubusercontent.com/10870130/35610793-fc2bb066-0662-11e8-8d40-189b66f7da1a.png)
