### PR TITLE
Be able to change the default features root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ Under the hood, the Cucumber Booster uses the following command:
 bundle exec cucumber <file_list>
 ```
 
+You can also change the default features root directory with by setting an environment variable:
+
+``` bash
+export DEFAULT_FEATURES_ROOT=acceptance
+```
+Now `cucumber_booster` will load all files matching `acceptance/**/*.feature`
+
 ## Minitest Booster
 
 The `minitest_booster` loads all the files that match the `test/**/*_test.rb`

--- a/lib/test_boosters/boosters/cucumber.rb
+++ b/lib/test_boosters/boosters/cucumber.rb
@@ -2,7 +2,7 @@ module TestBoosters
   module Boosters
     class Cucumber < Base
 
-      FILE_PATTERN = "features/**/*.feature".freeze
+      FILE_PATTERN = "#{ENV.fetch("DEFAULT_FEATURES_ROOT", 'features')}/**/*.feature".freeze
 
       def initialize
         super(FILE_PATTERN, split_configuration_path, "bundle exec cucumber")


### PR DESCRIPTION
Why?
If you use CI such as Semaphore, it will assume all your *.feature files
are under `features/**/*.feature` which may or may not be the case.

Our project happen to put our feature files in another directory. Now we
can customize the root directory by setting the `DEFAULT_FEATURES_ROOT`
environment variable.