### PR TITLE
Add TB_RSPEC_FORMATTER env variable to specify RSpec format

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,16 +122,16 @@ bundle exec rspec --format documentation --format json --out /home/<user>/rspec_
 ```
 
 Optionally, you can pass additional RSpec flags with the `TB_RSPEC_OPTIONS`
-environment variable:
+environment variable. You can also set a RSpec formatter with the `TB_RSPEC_FORMATTER` environment variable.
+Default formatter is `documentation`.
 
+
+Example:
 ``` bash
-TB_RSPEC_OPTIONS='--fail-fast=3' rspec_booster --job 4/32
-```
+TB_RSPEC_OPTIONS='--fail-fast=3' TB_RSPEC_FORMATTER=Fivemat rspec_booster --job 4/32
 
-The above command will execute:
-
-``` bash
-bundle exec rspec --fail-fast=3 --format documentation --format json --out /home/<user>/rspec_report.json <file_list>
+# will execute:
+bundle exec rspec --fail-fast=3 --format Fivemat --format json --out /home/<user>/rspec_report.json <file_list>
 ```
 
 ## Cucumber Booster

--- a/lib/test_boosters/boosters/rspec.rb
+++ b/lib/test_boosters/boosters/rspec.rb
@@ -25,8 +25,11 @@ module TestBoosters
       end
 
       def rspec_options
-        # rubocop:disable LineLength
-        @rspec_options ||= "#{ENV["TB_RSPEC_OPTIONS"]} --format documentation --require #{formatter_path} --format SemaphoreFormatter --out #{report_path}"
+        @rspec_options ||= begin
+          output_formatter = ENV.fetch("TB_RSPEC_FORMATTER", "documentation")
+          # rubocop:disable LineLength
+          "#{ENV["TB_RSPEC_OPTIONS"]} --format #{output_formatter} --require #{formatter_path} --format SemaphoreFormatter --out #{report_path}"
+        end
       end
 
       def report_path

--- a/spec/lib/test_boosters/boosters/rspec_spec.rb
+++ b/spec/lib/test_boosters/boosters/rspec_spec.rb
@@ -45,6 +45,28 @@ describe TestBoosters::Boosters::Rspec do
     end
   end
 
+  describe "#rspec_options" do
+    context "when TB_RSPEC_FORMATTER environment variable is not set" do
+      it "returns the SemaphoreFormatter with --format documentation" do
+        expect(booster.rspec_options).to include("--format documentation")
+      end
+    end
+
+    context "when TB_RSPEC_FORMATTER environment variable is set" do
+      around do |example|
+        ENV["TB_RSPEC_FORMATTER"] = "Fivemat"
+        example.run
+        ENV.delete("TB_RSPEC_FORMATTER")
+      end
+
+      it "returns the SemaphoreFormatter but removes --format documentation
+            and uses the option specified in env variable" do
+        expect(booster.rspec_options).not_to include("--format documentation")
+        expect(booster.rspec_options).to include("--format Fivemat")
+      end
+    end
+  end
+
   describe "#split_configuration_path" do
     before { ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = "/tmp/path.txt" }
 


### PR DESCRIPTION
Follow up of issue spoken with support

Preview of `README` changes:
<img width="951" alt="image" src="https://user-images.githubusercontent.com/8051/41855158-42565018-7892-11e8-80bd-5258513fccdd.png">
