### PR TITLE
Allow rspec file pattern to be set via env variable

### DIFF
--- a/lib/test_boosters/boosters/rspec.rb
+++ b/lib/test_boosters/boosters/rspec.rb
@@ -1,11 +1,8 @@
 module TestBoosters
   module Boosters
     class Rspec < Base
-
-      FILE_PATTERN = "spec/**/*_spec.rb".freeze
-
       def initialize
-        super(FILE_PATTERN, split_configuration_path, command)
+        super(file_pattern, split_configuration_path, command)
       end
 
       def display_header
@@ -44,6 +41,9 @@ module TestBoosters
         @formatter_path ||= File.join(::TestBoosters::ROOT_PATH, "rspec_formatters/semaphore_rspec3_json_formatter.rb")
       end
 
+      def file_pattern
+        ENV["TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN"] || "spec/**/*_spec.rb"
+      end
     end
   end
 end

--- a/spec/lib/test_boosters/boosters/rspec_spec.rb
+++ b/spec/lib/test_boosters/boosters/rspec_spec.rb
@@ -67,6 +67,24 @@ describe TestBoosters::Boosters::Rspec do
     end
   end
 
+  describe "#file_pattern" do
+    before { ENV["TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN"] = "feature/features/**/*_spec.rb" }
+
+    context "when the TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN environment variable is set" do
+      it "returns its values" do
+        expect(booster.file_pattern).to eq("feature/features/**/*_spec.rb")
+      end
+    end
+
+    context "when the TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN environment variable is not set" do
+      before { ENV.delete("TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN") }
+
+      it "returns the default rspec path" do
+        expect(booster.file_pattern).to eq("spec/**/*_spec.rb")
+      end
+    end
+  end
+
   describe "#split_configuration_path" do
     before { ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = "/tmp/path.txt" }
 


### PR DESCRIPTION
Closes https://github.com/renderedtext/test-boosters/issues/58

I used `TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN ` as there are many potential file patterns and that also matched the format found in the booster file.

If you'd like, I can update the RSPEC readme section as well.