### PR TITLE
Added a --dry-run option that just shows which tests will be run

### DIFF
--- a/lib/test_boosters/boosters/base.rb
+++ b/lib/test_boosters/boosters/base.rb
@@ -18,11 +18,27 @@ module TestBoosters
 
         known, leftover = distribution.files_for(job_index)
 
+        if cli_options[:dry_run]
+          show_files_for_dry_run("known", known)
+          show_files_for_dry_run("leftover", leftover)
+          return 0
+        end
+
         exit_status = TestBoosters::Job.run(@command, known, leftover)
 
         after_job # execute some activities when the job finishes
 
         exit_status
+      end
+
+      def show_files_for_dry_run(label, files)
+        if files.empty?
+          puts "[DRY RUN] No #{label} files."
+          return
+        end
+
+        puts "\n[DRY RUN] Running tests for #{label} files:"
+        puts files.map { |file| "- #{file}" }.join("\n")
       end
 
       def before_job

--- a/lib/test_boosters/cli_parser.rb
+++ b/lib/test_boosters/cli_parser.rb
@@ -9,14 +9,27 @@ module TestBoosters
       options = {}
 
       parser = OptionParser.new do |opts|
-        opts.on("--thread INDEX") do |parameter|
+        opts.on(
+          "--thread INDEX",
+          "[DEPRECATED] Use the '--job' option instead"
+        ) do |parameter|
           puts "[DEPRECATION WARNING] The '--thread' parameter is deprecated. Please use '--job' instead."
 
           options.merge!(parse_job_params(parameter))
         end
 
-        opts.on("--job INDEX") do |parameter|
+        opts.on(
+          "--job INDEX",
+          "The job index and number of total jobs. e.g. --job 4/32"
+        ) do |parameter|
           options.merge!(parse_job_params(parameter))
+        end
+
+        opts.on(
+          "--dry-run",
+          "Only print the files that will be run for this job index"
+        ) do |parameter|
+          options.merge!(:dry_run => parameter)
         end
       end
 
@@ -25,7 +38,7 @@ module TestBoosters
       options
     end
 
-    # parses input like '1/32' and ouputs { :job_index => 1, :job_count => 32 }
+    # parses input like '1/32' and outputs { :job_index => 1, :job_count => 32 }
     def parse_job_params(input_parameter)
       job_index, job_count, _rest = input_parameter.split("/")
 

--- a/spec/lib/test_boosters/boosters/base_spec.rb
+++ b/spec/lib/test_boosters/boosters/base_spec.rb
@@ -70,4 +70,34 @@ describe TestBoosters::Boosters::Base do
       booster.run
     end
   end
+
+  describe "#run with --dry-run option" do
+    before do
+      allow(TestBoosters::CliParser).to receive(:parse).and_return(
+        :job_index => 10, :job_count => 32, :dry_run => true)
+    end
+
+    it "only prints a list of files, and doesn't run any tests" do
+      expect(TestBoosters::Job).to_not receive(:run)
+      booster.run
+    end
+
+    context "with no known files" do
+      let(:known_files) { [] }
+
+      it "prints the correct log messages" do
+        expect(TestBoosters::Job).to_not receive(:run)
+        booster.run
+      end
+    end
+
+    context "with no leftover files" do
+      let(:leftover_files) { [] }
+
+      it "prints the correct log messages" do
+        expect(TestBoosters::Job).to_not receive(:run)
+        booster.run
+      end
+    end
+  end
 end

--- a/spec/lib/test_boosters/cli_parser_spec.rb
+++ b/spec/lib/test_boosters/cli_parser_spec.rb
@@ -42,6 +42,16 @@ describe TestBoosters::CliParser do
         expect(params).to eq(:job_index => 12, :job_count => 32)
       end
     end
+
+    context "cli params contain the dry-run parameter" do
+      it "recongnizes the --dry-run parameter" do
+        ARGV = ["--dry-run"] # rubocop:disable Style/MutableConstant
+
+        params = TestBoosters::CliParser.parse
+
+        expect(params).to eq(:dry_run => true)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
I just found test-boosters, and wanted to see what tests would be run for each job, so I added a new `--dry-run` option. (I also added some descriptions for the other CLI args.)

Unfortunately it's quite hard to get all of the tests running on my local machine, so I'm not sure about the coverage. Please let me know if I missed anything!

Example output from new spec:

```
TestBoosters::Boosters::Base
  #run
    with --dry-run option

=== Test Booster v2.4.0 - Job 10 out of 32 ====

[DRY RUN] Running tests for known files:
- file1.rb
- file2.rb

[DRY RUN] Running tests for leftover files:
- file3.rb
- file4.rb
```