### PR TITLE
Added support for file exclude pattern that can be set with TEST_BOOSTERS_RSPEC_TEST_EXCLUDE_PATTERN

### DIFF
--- a/lib/test_boosters/boosters/base.rb
+++ b/lib/test_boosters/boosters/base.rb
@@ -2,9 +2,10 @@ module TestBoosters
   module Boosters
     class Base
 
-      def initialize(file_pattern, split_configuration_path, command)
+      def initialize(file_pattern, exclude_pattern, split_configuration_path, command)
         @command = command
         @file_pattern = file_pattern
+        @exclude_pattern = exclude_pattern
         @split_configuration_path = split_configuration_path
       end
 
@@ -59,6 +60,7 @@ module TestBoosters
       def distribution
         @distribution ||= TestBoosters::Files::Distributor.new(@split_configuration_path,
                                                                @file_pattern,
+                                                               @exclude_pattern,
                                                                job_count)
       end
 

--- a/lib/test_boosters/boosters/cucumber.rb
+++ b/lib/test_boosters/boosters/cucumber.rb
@@ -5,7 +5,7 @@ module TestBoosters
       FILE_PATTERN = "features/**/*.feature".freeze
 
       def initialize
-        super(FILE_PATTERN, split_configuration_path, "bundle exec cucumber")
+        super(FILE_PATTERN, nil, split_configuration_path, "bundle exec cucumber")
       end
 
       def before_job

--- a/lib/test_boosters/boosters/ex_unit.rb
+++ b/lib/test_boosters/boosters/ex_unit.rb
@@ -5,7 +5,7 @@ module TestBoosters
       FILE_PATTERN = "test/**/*_test.exs".freeze
 
       def initialize
-        super(FILE_PATTERN, split_configuration_path, "mix test")
+        super(FILE_PATTERN, nil, split_configuration_path, "mix test")
       end
 
       def split_configuration_path

--- a/lib/test_boosters/boosters/go_test.rb
+++ b/lib/test_boosters/boosters/go_test.rb
@@ -5,7 +5,7 @@ module TestBoosters
       FILE_PATTERN = "**/*/*_test.go".freeze
 
       def initialize
-        super(FILE_PATTERN, split_configuration_path, "go test")
+        super(FILE_PATTERN, nil, split_configuration_path, "go test")
       end
 
       def split_configuration_path

--- a/lib/test_boosters/boosters/minitest.rb
+++ b/lib/test_boosters/boosters/minitest.rb
@@ -5,7 +5,7 @@ module TestBoosters
       FILE_PATTERN = "test/**/*_test.rb".freeze
 
       def initialize
-        super(FILE_PATTERN, split_configuration_path, command)
+        super(FILE_PATTERN, nil, split_configuration_path, command)
       end
 
       def command

--- a/lib/test_boosters/boosters/rspec.rb
+++ b/lib/test_boosters/boosters/rspec.rb
@@ -2,7 +2,7 @@ module TestBoosters
   module Boosters
     class Rspec < Base
       def initialize
-        super(file_pattern, split_configuration_path, command)
+        super(file_pattern, exclude_pattern, split_configuration_path, command)
       end
 
       def display_header
@@ -43,6 +43,10 @@ module TestBoosters
 
       def file_pattern
         ENV["TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN"] || "spec/**/*_spec.rb"
+      end
+
+      def exclude_pattern
+        ENV["TEST_BOOSTERS_RSPEC_TEST_EXCLUDE_PATTERN"]
       end
     end
   end

--- a/lib/test_boosters/files/distributor.rb
+++ b/lib/test_boosters/files/distributor.rb
@@ -6,9 +6,10 @@ module TestBoosters
     #
     class Distributor
 
-      def initialize(split_configuration_path, file_pattern, job_count)
+      def initialize(split_configuration_path, file_pattern, exclude_pattern, job_count)
         @split_configuration_path = split_configuration_path
         @file_pattern = file_pattern
+        @exclude_pattern = exclude_pattern
         @job_count = job_count
       end
 
@@ -26,7 +27,11 @@ module TestBoosters
       end
 
       def all_files
-        @all_files ||= Dir[@file_pattern].sort
+        @all_files ||= begin
+          files = Dir[@file_pattern].sort
+          files -= Dir[@exclude_pattern] if @exclude_pattern
+          files
+        end
       end
 
       private

--- a/spec/lib/test_boosters/boosters/base_spec.rb
+++ b/spec/lib/test_boosters/boosters/base_spec.rb
@@ -20,14 +20,14 @@ describe TestBoosters::Boosters::Base do
   let(:command) { "test_runner_command" }
   let(:split_configuration_path) { "/home/split_configuration.json" }
 
-  subject(:booster) { described_class.new(file_pattern, split_configuration_path, command) }
+  subject(:booster) { described_class.new(file_pattern, nil, split_configuration_path, command) }
 
   it { expect(booster.job_index).to eq(9) }
   it { expect(booster.job_count).to eq(32) }
 
   describe "#distribution" do
     it "returns an instance of the file distributor" do
-      expect(TestBoosters::Files::Distributor).to receive(:new).with(split_configuration_path, file_pattern, 32)
+      expect(TestBoosters::Files::Distributor).to receive(:new).with(split_configuration_path, file_pattern, nil, 32)
 
       booster.distribution
     end

--- a/spec/lib/test_boosters/boosters/rspec_spec.rb
+++ b/spec/lib/test_boosters/boosters/rspec_spec.rb
@@ -85,6 +85,27 @@ describe TestBoosters::Boosters::Rspec do
     end
   end
 
+  describe "#exclude_pattern" do
+    before do
+      ENV["TEST_BOOSTERS_RSPEC_TEST_EXCLUDE_PATTERN"] =
+        "feature/features/**/*_spec.rb"
+    end
+
+    context "when the TEST_BOOSTERS_RSPEC_TEST_EXCLUDE_PATTERN environment variable is set" do
+      it "returns its values" do
+        expect(booster.exclude_pattern).to eq("feature/features/**/*_spec.rb")
+      end
+    end
+
+    context "when the TEST_BOOSTERS_RSPEC_TEST_FILE_PATTERN environment variable is not set" do
+      before { ENV.delete("TEST_BOOSTERS_RSPEC_TEST_EXCLUDE_PATTERN") }
+
+      it "returns nil" do
+        expect(booster.exclude_pattern).to be_nil
+      end
+    end
+  end
+
   describe "#split_configuration_path" do
     before { ENV["RSPEC_SPLIT_CONFIGURATION_PATH"] = "/tmp/path.txt" }
 

--- a/spec/lib/test_boosters/files/distributor_spec.rb
+++ b/spec/lib/test_boosters/files/distributor_spec.rb
@@ -17,12 +17,13 @@ describe TestBoosters::Files::Distributor do
     ])
 
     @file_pattern = "#{@base_path}/spec/**/*_spec.rb"
+    @exclude_pattern = nil
   end
 
-  subject(:distributor) { described_class.new(@split_configuration_path, @file_pattern, 10) }
+  subject(:distributor) { described_class.new(@split_configuration_path, @file_pattern, @exclude_pattern, 10) }
 
   describe "#all_files" do
-    it "returns all files that mathc the pattern" do
+    it "returns all files that match the pattern" do
       expect(distributor.all_files).to eq([
         "#{@base_path}/spec/a_spec.rb",
         "#{@base_path}/spec/lib/b_spec.rb",
@@ -50,4 +51,37 @@ describe TestBoosters::Files::Distributor do
     it { is_expected.to output(/Split configuration file count: 1/).to_stdout }
   end
 
+  context "with exclude pattern" do
+    before do
+      @exclude_pattern = "#{@base_path}/spec/**/c_spec*"
+    end
+
+    describe "#all_files" do
+      it "returns all files that match the pattern, but don't match the exclude pattern" do
+        expect(distributor.all_files).to eq([
+          "#{@base_path}/spec/a_spec.rb",
+          "#{@base_path}/spec/lib/b_spec.rb"
+        ].sort)
+      end
+    end
+
+    describe "#files_for" do
+      it "lists all files that match the pattern but are not in the split conf" do
+        known, leftover = distributor.files_for(0)
+
+        expect(known).to eq(["#{@base_path}/spec/a_spec.rb"])
+        expect(leftover).to eq(["#{@base_path}/spec/lib/b_spec.rb"])
+      end
+    end
+
+    describe "#display_info" do
+      subject do
+        -> { distributor.display_info }
+      end
+
+      it { is_expected.to output(/Split configuration present: yes/).to_stdout }
+      it { is_expected.to output(/Split configuration valid: yes/).to_stdout }
+      it { is_expected.to output(/Split configuration file count: 1/).to_stdout }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #71. Related to #68 (but exclude instead of include)

This PR adds a `TEST_BOOSTERS_RSPEC_TEST_EXCLUDE_PATTERN` env variable to exclude some files with a glob pattern. (Similar to the `--exclude-pattern` option for RSpec, which doesn't work when we specify a list of explicit files.)