### PR TITLE
Add a TB_DISABLE_INSIGHTS env variable to disable the insights uploading step

### DIFF
--- a/lib/test_boosters/insights_uploader.rb
+++ b/lib/test_boosters/insights_uploader.rb
@@ -3,7 +3,7 @@ module TestBoosters
     module_function
 
     def upload(booster_type, file)
-      return unless File.exist?(file)
+      return if ENV['TB_DISABLE_INSIGHTS'] || !File.exist?(file)
 
       cmd = "http POST '#{insights_url}' #{booster_type}:=@#{file}"
 


### PR DESCRIPTION
I've added a `TB_DISABLE_INSIGHTS` env variable that users can set to disable the "analytics" step. (I use this gem on GitLab CI instead of Semaphore.) This is related to #74 