### PR TITLE
Use `Bundler.with_unbundled_env`

### DIFF
--- a/lib/test_boosters/shell.rb
+++ b/lib/test_boosters/shell.rb
@@ -29,7 +29,7 @@ module TestBoosters
     end
 
     def with_clean_env
-      defined?(Bundler) ? Bundler.with_clean_env { yield } : yield
+      defined?(Bundler) ? Bundler.with_original_env { yield } : yield
     end
 
     def display_title(title)

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -29,7 +29,7 @@ module IntegrationHelper
 
     # :reek:TooManyStatements
     def run_command(command)
-      Bundler.with_clean_env do
+      Bundler.with_original_env do
         cmd = "cd #{@project_path} && #{@env} #{command}"
 
         puts "Running: #{cmd}"


### PR DESCRIPTION
`Bundler.with_clean_env` has been deprecated, so update the code to use
`Bundler.with_unbundled_env` instead.