### PR TITLE
Only upload insights if `http` command is present

### DIFF
--- a/lib/test_boosters/insights_uploader.rb
+++ b/lib/test_boosters/insights_uploader.rb
@@ -3,7 +3,7 @@ module TestBoosters
     module_function
 
     def upload(booster_type, file)
-      return unless File.exist?(file)
+      return unless system('which http') && File.exist?(file)
 
       cmd = "http POST '#{insights_url}' #{booster_type}:=@#{file}"
 


### PR DESCRIPTION
Check for the presence of the `http` command before attempting to send insights to avoid not found errors in environments where the command isn't installed.