### PR TITLE
enable passing of cucumber runtime args

### DIFF
--- a/lib/test_boosters/boosters/cucumber.rb
+++ b/lib/test_boosters/boosters/cucumber.rb
@@ -5,7 +5,7 @@ module TestBoosters
       FILE_PATTERN = "features/**/*.feature".freeze
 
       def initialize
-        super(FILE_PATTERN, nil, split_configuration_path, "bundle exec cucumber")
+        super(FILE_PATTERN, nil, split_configuration_path, "bundle exec #{command}")
       end
 
       def before_job
@@ -32,6 +32,15 @@ module TestBoosters
         ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] || "#{ENV["HOME"]}/cucumber_split_configuration.json"
       end
 
+      private
+
+      def command
+        if ENV["CUCUMBER_ARGS"]
+          "cucumber #{ENV["CUCUMBER_ARGS"]}"
+        else
+          "cucumber"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
with newer cucumber versions (>5) and rails >= 6.1 on semaphore there is no output when running cucumber tests unless `--verbose` is explicitly passed and this can make debugging debugging quite difficult. It's currently not possible to pass in these cucumber args to the `cucumber_booster` script. Allow it to load args from an environment variable that can be set in the build container

e.g. 

`CUCUMBER_ARGS="--backtrack --verbose --format pretty" cucumber_booster --job $SEMAPHORE_JOB_INDEX/$SEMAPHORE_JOB_COUNT`

will provide a nice verbose output that allows debugging of any test failures without having to SSH in to a build container and poke around in the logs

