### PR TITLE
Add minitest support for file exclude pattern

### DIFF
--- a/lib/test_boosters/boosters/minitest.rb
+++ b/lib/test_boosters/boosters/minitest.rb
@@ -5,7 +5,7 @@ module TestBoosters
       FILE_PATTERN = "test/**/*_test.rb".freeze
 
       def initialize
-        super(FILE_PATTERN, nil, split_configuration_path, command)
+        super(file_pattern, exclude_pattern, split_configuration_path, command)
       end
 
       def command
@@ -28,6 +28,14 @@ module TestBoosters
 
       def command_from_env_var
         ENV["MINITEST_BOOSTER_COMMAND"].to_s
+      end
+
+      def file_pattern
+        ENV["TEST_BOOSTERS_MINITEST_TEST_FILE_PATTERN"] || FILE_PATTERN
+      end
+
+      def exclude_pattern
+        ENV["TEST_BOOSTERS_MINITEST_TEST_EXCLUDE_PATTERN"]
       end
 
       private

--- a/spec/lib/test_boosters/boosters/minitest_spec.rb
+++ b/spec/lib/test_boosters/boosters/minitest_spec.rb
@@ -56,4 +56,43 @@ describe TestBoosters::Boosters::Minitest do
       end
     end
   end
+
+  describe "#file_pattern" do
+    before { ENV["TEST_BOOSTERS_MINITEST_TEST_FILE_PATTERN"] = "test/system/**/*_test.rb" }
+
+    context "when the TEST_BOOSTERS_MINITEST_TEST_FILE_PATTERN environment variable is set" do
+      it "returns its values" do
+        expect(booster.file_pattern).to eq("test/system/**/*_test.rb")
+      end
+    end
+
+    context "when the TEST_BOOSTERS_MINITEST_TEST_FILE_PATTERN environment variable is not set" do
+      before { ENV.delete("TEST_BOOSTERS_MINITEST_TEST_FILE_PATTERN") }
+
+      it "returns the default minitest path" do
+        expect(booster.file_pattern).to eq("test/**/*_test.rb")
+      end
+    end
+  end
+
+  describe "#exclude_pattern" do
+    before do
+      ENV["TEST_BOOSTERS_MINITEST_TEST_EXCLUDE_PATTERN"] =
+        "test/system/**/*_test.rb"
+    end
+
+    context "when the TEST_BOOSTERS_MINITEST_TEST_EXCLUDE_PATTERN environment variable is set" do
+      it "returns its values" do
+        expect(booster.exclude_pattern).to eq("test/system/**/*_test.rb")
+      end
+    end
+
+    context "when the TEST_BOOSTERS_MINITEST_TEST_FILE_PATTERN environment variable is not set" do
+      before { ENV.delete("TEST_BOOSTERS_MINITEST_TEST_EXCLUDE_PATTERN") }
+
+      it "returns nil" do
+        expect(booster.exclude_pattern).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Issue https://github.com/renderedtext/test-boosters/issues/91
* Based on rspec support added here https://github.com/renderedtext/test-boosters/pull/72
* Adds support for minitest include and exclude patterns based on `TEST_BOOSTERS_MINITEST_TEST_FILE_PATTERN` and `TEST_BOOSTERS_MINITEST_TEST_EXCLUDE_PATTERN` env vars.