### PR TITLE
Replace Bundler.with_clean_env with Bundler.with_unbundled_env

### DIFF
--- a/lib/test_boosters/shell.rb
+++ b/lib/test_boosters/shell.rb
@@ -29,7 +29,15 @@ module TestBoosters
     end
 
     def with_clean_env
-      defined?(Bundler) ? Bundler.with_clean_env { yield } : yield
+      if defined?(Bundler)
+        if Bundler.respond_to?(:with_unbundled_env)
+          Bundler.with_unbundled_env { yield }
+        else
+          Bundler.with_clean_env { yield }
+        end
+      else
+        yield
+      end
     end
 
     def display_title(title)


### PR DESCRIPTION
## Problem

`Bundler.with_clean_env` was deprecated in Bundler 2.1 and has been fully removed in Bundler 4.0 (shipped with Ruby 4.0.1). This causes `semaphore_test_boosters` to crash with a `Bundler::RemovedError` when used with Ruby 4.0+:

```
[REMOVED] `Bundler.with_clean_env` has been removed in favor of `Bundler.with_unbundled_env`.
If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env`
(Bundler::RemovedError)
```

This affects both `minitest_booster` and `rspec_booster` commands, making the gem completely unusable with modern Ruby/Bundler versions.

## Solution

Replace the call to `Bundler.with_clean_env` with `Bundler.with_unbundled_env` in `TestBoosters::Shell.with_clean_env`. The fix uses `respond_to?` to check for the new method first, falling back to the old method for backward compatibility with Bundler < 2.1.

## Changes

- `lib/test_boosters/shell.rb`: Updated `with_clean_env` to prefer `Bundler.with_unbundled_env` when available, falling back to `Bundler.with_clean_env` for older Bundler versions.

## Testing

- Compatible with Bundler 1.x/2.x (uses `with_clean_env` fallback)
- Compatible with Bundler 4.x (uses `with_unbundled_env`)
- `with_unbundled_env` has been available since Bundler 2.1 (released 2019)