### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/test_boosters.gemspec
+++ b/test_boosters.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/renderedtext/test-boosters"
   spec.license       = "MIT"
 
-  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z lib exe rspec_formatters LICENSE.txt README.md`.split("\x0")
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 16K	before.tar
 12K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 16K   | 12K   | −4K (⏷ −25%)     |


###  whitch files was deleted?

```diff
data
-├── bin
-│   ├── console
-│   └── setup
 ├── exe
 │   ├── cucumber_booster
 │   ├── ex_unit_booster
 │   ├── go_test_booster
 │   ├── minitest_booster
 │   └── rspec_booster
 ├── lib
 │   ├── test_boosters
 │   │   ├── boosters
 │   │   │   ├── base.rb
 │   │   │   ├── cucumber.rb
 │   │   │   ├── ex_unit.rb
 │   │   │   ├── go_test.rb
 │   │   │   ├── minitest.rb
 │   │   │   └── rspec.rb
 │   │   ├── files
 │   │   │   ├── distributor.rb
 │   │   │   ├── leftover_files.rb
 │   │   │   └── split_configuration.rb
 │   │   ├── cli_parser.rb
 │   │   ├── insights_uploader.rb
 │   │   ├── job.rb
 │   │   ├── logger.rb
 │   │   ├── project_info.rb
 │   │   ├── shell.rb
 │   │   └── version.rb
 │   └── test_boosters.rb
 ├── rspec_formatters
 │   └── semaphore_rspec3_json_formatter.rb
-├── .gitignore
-├── .rspec
-├── .rubocop.yml
-├── config.reek
-├── Gemfile
 ├── LICENSE.txt
-├── Rakefile
 ├── README.md
-└── test_boosters.gemspec
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)